### PR TITLE
docs: GitHub Issueテンプレートを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,128 @@
+name: バグ報告
+description: バグ・不具合の報告
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグ報告ありがとうございます。
+        以下のテンプレートに沿って記載してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 発生しているバグの概要を簡潔に記載してください
+      placeholder: |
+        例: 日付選択時にエラーが発生する
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: 再現手順
+      description: バグを再現する手順を記載してください
+      placeholder: |
+        1. トップページを開く
+        2. 日付選択で「2025/01/01」を選択
+        3. 「レース一覧」ボタンをクリック
+        4. エラーが発生する
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 期待する動作
+      description: 本来どのように動作すべきかを記載してください
+      placeholder: |
+        例: 選択した日付のレース一覧が表示される
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: 実際の動作
+      description: 実際に発生している動作を記載してください（エラーメッセージ、スクリーンショットなど）
+      placeholder: |
+        例: 「TypeError: Cannot read property 'xxx' of undefined」が発生する
+
+        ```
+        エラーログ
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: affected-files
+    attributes:
+      label: 影響範囲
+      description: |
+        関連するファイルパス、コード箇所があれば記載してください
+      placeholder: |
+        **ファイル**: `frontend/src/components/DatePicker.tsx`
+
+        ```typescript
+        // 問題のあるコード（推測）
+        ```
+    validations:
+      required: false
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: 環境
+      description: バグが発生した環境を選択してください
+      options:
+        - 本番環境
+        - 開発環境（ローカル）
+        - 両方
+    validations:
+      required: true
+
+  - type: textarea
+    id: browser-info
+    attributes:
+      label: ブラウザ・OS情報
+      description: 使用しているブラウザとOS情報を記載してください
+      placeholder: |
+        - ブラウザ: Chrome 120
+        - OS: macOS 14.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: 修正タスク
+      description: 修正に必要なタスクをチェックリストで記載してください（わかる範囲で）
+      placeholder: |
+        - [ ] 原因調査
+        - [ ] 修正実装
+        - [ ] テスト追加
+        - [ ] 動作確認
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 受け入れ条件
+      description: バグが修正されたとみなす条件を記載してください
+      placeholder: |
+        - [ ] 日付選択時にエラーが発生しない
+        - [ ] 選択した日付のレース一覧が表示される
+        - [ ] 既存のテストが通る
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 補足情報
+      description: その他補足があれば記載してください（スクリーンショット、ログなど）
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 質問・相談
+    url: https://github.com/foie0222/baken-kaigi/discussions
+    about: 機能要望やバグ報告ではない質問・相談はDiscussionsをご利用ください

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,118 @@
+name: 機能リクエスト
+description: 新機能の提案・追加要望
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        新機能の提案ありがとうございます。
+        以下のテンプレートに沿って記載してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 実装したい機能の概要を簡潔に記載してください
+      placeholder: |
+        例: 馬番号バッジの色をJRA公式の枠色に合わせたい
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景・動機
+      description: なぜこの機能が必要なのか、どのような課題を解決するのかを記載してください
+      placeholder: |
+        例: 現在の色がJRA公式と異なり、ユーザーの直感に反するため修正したい
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-state
+    attributes:
+      label: 現状
+      description: |
+        現在の状態（関連コード、スクリーンショットなど）を記載してください
+        ファイルパスやコード例があると実装がスムーズになります
+      placeholder: |
+        **ファイル**: `frontend/src/types/index.ts`
+
+        ```typescript
+        // 現在のコード
+        ```
+
+        **問題点**:
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: 提案する解決策
+      description: どのように実装すべきか、技術的な考慮点があれば記載してください
+      placeholder: |
+        ## 実装方針
+
+        ### バックエンド
+        - DBスキーマの変更
+        - API修正
+
+        ### フロントエンド
+        - コンポーネント修正
+
+        ## 技術的考慮点
+        - パフォーマンス
+        - 互換性
+    validations:
+      required: false
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: タスク
+      description: 実装に必要なタスクをチェックリストで記載してください
+      placeholder: |
+        ### バックエンド
+        - [ ] DBスキーマ修正
+        - [ ] API修正
+        - [ ] テスト追加
+
+        ### フロントエンド
+        - [ ] コンポーネント修正
+        - [ ] テスト追加
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 受け入れ条件
+      description: この機能が完成したとみなす条件を記載してください
+      placeholder: |
+        - [ ] 〇〇が表示される
+        - [ ] △△の場合に□□が動作する
+        - [ ] テストが通る
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 参考資料
+      description: 参考になるドキュメント、デザイン、スクリーンショットなどがあれば記載してください
+      placeholder: |
+        - [JRA公式サイト](https://www.jra.go.jp/)
+        - デザインモック: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 補足情報
+      description: その他補足があれば記載してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,132 @@
+name: 改善提案
+description: リファクタリング、パフォーマンス改善、コード品質向上など
+title: "refactor: "
+labels: ["improvement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        改善提案ありがとうございます。
+        以下のテンプレートに沿って記載してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 改善したい内容の概要を簡潔に記載してください
+      placeholder: |
+        例: APIクライアントの共通処理を抽出してDRY原則に従う
+    validations:
+      required: true
+
+  - type: dropdown
+    id: improvement-type
+    attributes:
+      label: 改善の種類
+      description: 改善の種類を選択してください
+      options:
+        - リファクタリング
+        - パフォーマンス改善
+        - コード品質向上
+        - テスト追加・改善
+        - ドキュメント改善
+        - セキュリティ改善
+        - その他
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-state
+    attributes:
+      label: 現状の問題点
+      description: 現在の状態と問題点を記載してください
+      placeholder: |
+        **ファイル**: `frontend/src/api/client.ts`
+
+        ```typescript
+        // 現在のコード
+        ```
+
+        **問題点**:
+        - 同じ処理が複数箇所に散在している
+        - エラーハンドリングが統一されていない
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: 提案する改善案
+      description: どのように改善すべきか記載してください
+      placeholder: |
+        ## 改善方針
+
+        1. 共通処理を抽出
+        2. エラーハンドリングを統一
+        3. 型定義を改善
+
+        ## 改善後のイメージ
+
+        ```typescript
+        // 改善後のコード例
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefits
+    attributes:
+      label: 期待される効果
+      description: この改善によってどのような効果が得られるか記載してください
+      placeholder: |
+        - コードの重複削減
+        - 保守性の向上
+        - テストしやすくなる
+        - パフォーマンス向上（〇〇ms → △△ms）
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: リスク・考慮事項
+      description: この改善に伴うリスクや注意点があれば記載してください
+      placeholder: |
+        - 影響範囲が広い
+        - 既存のテストの修正が必要
+        - 後方互換性の考慮が必要
+    validations:
+      required: false
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: タスク
+      description: 改善に必要なタスクをチェックリストで記載してください
+      placeholder: |
+        - [ ] 共通処理の抽出
+        - [ ] 既存コードの修正
+        - [ ] テストの修正・追加
+        - [ ] 動作確認
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 受け入れ条件
+      description: この改善が完了したとみなす条件を記載してください
+      placeholder: |
+        - [ ] 既存のテストが全て通る
+        - [ ] 新しいテストが追加されている
+        - [ ] コードの重複がなくなっている
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 補足情報
+      description: その他補足があれば記載してください
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- GitHub Issueテンプレートを3種類追加
  - 機能リクエスト（feature_request.yml）
  - バグ報告（bug_report.yml）
  - 改善提案（improvement.yml）
- 空のIssue作成を無効化し、質問はDiscussionsへ誘導する設定を追加

## Test plan
- [ ] GitHub上で「New Issue」をクリックし、テンプレート選択画面が表示されることを確認
- [ ] 各テンプレートを選択し、フォームが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)