### PR TITLE
chore: git worktree ディレクトリを .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ jravan-api/test_*.py
 
 # uv lock file
 uv.lock
+
+# Git worktrees
+/.bare/
+/main/
+/feature-*/
+/fix-*/
+/docs-*/
+/chore-*/


### PR DESCRIPTION
## Summary
- git worktree 運用に対応するため、.gitignore に worktree ディレクトリを追加
- `.bare/`, `/main/`, `/feature-*/`, `/fix-*/`, `/docs-*/`, `/chore-*/` を除外

## Test plan
- [ ] git worktree list でワークツリー一覧が正常に表示される
- [ ] IDE で .bare/ 以下が差分として表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)