### PR TITLE
feat: グレードバッジの色をJRA公式カラーに変更

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -370,8 +370,8 @@ main {
 }
 
 .grade-badge.g1 {
-    background: linear-gradient(135deg, #d4af37, #f4d03f);
-    color: #1a1a1a;
+    background: linear-gradient(135deg, #1a5fb4, #3584e4);
+    color: white;
 }
 
 .grade-badge.g2 {
@@ -380,7 +380,7 @@ main {
 }
 
 .grade-badge.g3 {
-    background: linear-gradient(135deg, #2980b9, #3498db);
+    background: linear-gradient(135deg, #26a269, #33d17a);
     color: white;
 }
 


### PR DESCRIPTION
## Summary

- グレードバッジの色をJRA公式カラーに変更
  - G1: 金色 → 青
  - G2: 赤（変更なし）
  - G3: 青 → 緑

## Test plan

- [ ] ローカルでG1/G2/G3レースの色を確認
- [ ] 本番環境でバッジ色が正しく表示されることを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)