### PR TITLE
feat: カスタムスキル/エージェントを追加

### DIFF
--- a/.claude/agents/frontend-mapper.md
+++ b/.claude/agents/frontend-mapper.md
@@ -1,0 +1,422 @@
+---
+name: frontend-mapper
+description: バックエンドAPIレスポンスからTypeScript型とマッピング関数を自動生成
+version: 1.0.0
+type: agent
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+---
+
+# フロントエンドマッピング生成サブエージェント
+
+## 概要
+
+バックエンドAPIのレスポンス定義から、フロントエンド用のTypeScript型定義とマッピング関数を自動生成します。型安全性を保証し、API変更時のフロントエンド更新作業を効率化します。
+
+## 実行タイミング
+
+以下の状況で本エージェントを起動してください:
+
+- 新しいAPIエンドポイントを追加した時
+- 既存APIレスポンスにフィールドを追加/変更した時
+- データ構造の大幅な変更がある時
+
+## マッピング戦略
+
+### 命名規則
+
+**バックエンド（Python）**:
+- snake_case（例: `race_id`, `horse_count`）
+- データクラス: PascalCase（例: `RaceData`, `RunnerData`）
+
+**フロントエンド（TypeScript）**:
+- API型: `Api` プレフィックス + snake_case（例: `ApiRace`, `ApiRunner`）
+- 表示用型: PascalCase + camelCase フィールド（例: `Race`, `Runner`）
+
+### 型マッピングルール
+
+| Python型 | TypeScript API型 | TypeScript表示用型 |
+|---------|-----------------|------------------|
+| `str` | `string` | `string` |
+| `int` | `number` | `number` |
+| `float` | `number` | `number` |
+| `bool` | `boolean` | `boolean` |
+| `datetime` | `string` (ISO形式) | `string` (表示形式) |
+| `list[T]` | `T[]` | `T[]` |
+| `dict[K, V]` | `Record<K, V>` | `Record<K, V>` |
+| `T \| None` | `T \| undefined` | `T?` (optional) |
+
+## 実行プロセス
+
+### ステップ1: バックエンドAPIの分析
+
+#### 対象ファイル
+- `main/backend/src/api/handlers/*.py`
+- `main/backend/src/domain/ports/*.py`
+
+#### 抽出情報
+1. エンドポイントパス
+2. レスポンス構造
+3. フィールド名と型
+4. オプショナルフィールド
+
+**分析例（races.py）**:
+```python
+def get_race_detail(event: dict, context: Any) -> dict:
+    # ...
+    return success_response({
+        "race": {
+            "race_id": str,
+            "race_name": str,
+            "race_number": int,
+            "venue": str,
+            "start_time": str,  # ISO format
+            "track_condition": str,
+            "distance": int | None,
+        },
+        "runners": list[{
+            "horse_number": int,
+            "horse_name": str,
+            "jockey_name": str,
+            "odds": str,
+            "weight": int | None,
+        }]
+    })
+```
+
+### ステップ2: TypeScript API型の生成
+
+**ファイル**: `main/frontend/src/types/index.ts`
+
+**生成パターン**:
+```typescript
+// バックエンドレスポンス型（API型）
+export interface ApiRace {
+  race_id: string;
+  race_name: string;
+  race_number: number;
+  venue: string;
+  start_time: string;  // ISO 8601形式
+  track_condition: string;
+  distance?: number;   // オプショナル
+}
+
+export interface ApiRunner {
+  horse_number: number;
+  horse_name: string;
+  jockey_name: string;
+  odds: string;
+  weight?: number;
+}
+
+export interface ApiRaceDetailResponse {
+  race: ApiRace;
+  runners: ApiRunner[];
+}
+```
+
+**重要な原則**:
+- フィールド名はバックエンドと完全一致（snake_case）
+- オプショナルフィールドは `?` で表現
+- ネストした型も個別に定義
+
+### ステップ3: フロントエンド表示用型の生成
+
+**生成パターン**:
+```typescript
+// フロントエンド表示用型（camelCase）
+export interface Race {
+  id: string;
+  name: string;
+  number: string;      // 表示用に "1R" 形式
+  venue: string;
+  time: string;        // "15:40" 形式
+  condition: string;
+  distance?: number;
+}
+
+export interface Runner {
+  number: number;
+  name: string;
+  jockey: string;
+  odds: number;        // 文字列を数値に変換
+  weight?: number;
+}
+
+export interface RaceDetail {
+  race: Race;
+  runners: Runner[];
+}
+```
+
+**変換ルール**:
+1. **レース番号**: `race_number: number` → `number: string` ("1R")
+2. **時刻**: `start_time: string` → `time: string` ("15:40")
+3. **オッズ**: `odds: string` → `odds: number` (parseFloat)
+
+### ステップ4: マッピング関数の生成
+
+**生成パターン**:
+```typescript
+export function mapApiRaceToRace(apiRace: ApiRace): Race {
+  const startTime = new Date(apiRace.start_time);
+  const hours = startTime.getHours().toString().padStart(2, '0');
+  const minutes = startTime.getMinutes().toString().padStart(2, '0');
+
+  return {
+    id: apiRace.race_id,
+    name: apiRace.race_name,
+    number: `${apiRace.race_number}R`,
+    venue: apiRace.venue,
+    time: `${hours}:${minutes}`,
+    condition: apiRace.track_condition,
+    distance: apiRace.distance,
+  };
+}
+
+export function mapApiRunnerToRunner(apiRunner: ApiRunner): Runner {
+  return {
+    number: apiRunner.horse_number,
+    name: apiRunner.horse_name,
+    jockey: apiRunner.jockey_name,
+    odds: parseFloat(apiRunner.odds),
+    weight: apiRunner.weight,
+  };
+}
+
+export function mapApiRaceDetailToRaceDetail(
+  apiRace: ApiRace,
+  runners: ApiRunner[]
+): RaceDetail {
+  return {
+    race: mapApiRaceToRace(apiRace),
+    runners: runners.map(mapApiRunnerToRunner),
+  };
+}
+```
+
+**重要な原則**:
+- 関数名: `mapApi<Type>To<Type>`
+- 純粋関数（副作用なし）
+- null/undefined ハンドリング
+
+### ステップ5: APIクライアントの更新
+
+**ファイル**: `main/frontend/src/api/client.ts`
+
+**生成パターン**:
+```typescript
+async getRaceDetail(raceId: string): Promise<ApiResponse<RaceDetail>> {
+  const response = await this.request<ApiRaceDetailResponse>(
+    `/races/${encodeURIComponent(raceId)}`
+  );
+
+  if (!response.success || !response.data) {
+    return { success: false, error: response.error };
+  }
+
+  return {
+    success: true,
+    data: mapApiRaceDetailToRaceDetail(
+      response.data.race,
+      response.data.runners
+    ),
+  };
+}
+```
+
+**重要な原則**:
+- URLパラメータは `encodeURIComponent()` でエンコード
+- エラーハンドリングを統一
+- マッピング関数を使用して変換
+
+### ステップ6: 型チェックと検証
+
+**コマンド**:
+```bash
+cd main/frontend
+npm run typecheck
+```
+
+**検証項目**:
+- [ ] API型とバックエンドレスポンスの一致
+- [ ] マッピング関数の型安全性
+- [ ] オプショナルフィールドの適切な扱い
+- [ ] 型エラーがないこと
+
+## 出力形式
+
+### マッピング生成開始時
+
+```
+🔄 フロントエンドマッピング生成開始
+
+対象API: GET /races/{race_id}
+
+バックエンドレスポンス:
+- race: ApiRace
+  - race_id: string
+  - race_name: string
+  - race_number: number
+  - start_time: string (datetime)
+  - distance?: number
+- runners: ApiRunner[]
+  - horse_number: number
+  - horse_name: string
+  - weight?: number
+```
+
+### 型生成完了時
+
+```
+✅ TypeScript型定義生成完了
+
+追加した型:
+- ApiRace (API型)
+- ApiRunner (API型)
+- ApiRaceDetailResponse (API型)
+- Race (表示用型)
+- Runner (表示用型)
+- RaceDetail (表示用型)
+
+マッピング関数:
+- mapApiRaceToRace()
+- mapApiRunnerToRunner()
+- mapApiRaceDetailToRaceDetail()
+
+更新ファイル:
+- frontend/src/types/index.ts
+- frontend/src/api/client.ts
+```
+
+### 型チェック結果
+
+```
+🔍 型チェック実行中...
+
+✅ 型エラーなし
+
+次のアクション:
+- [ ] npm run build で動作確認
+- [ ] UIコンポーネントでの利用
+```
+
+## エラーハンドリング
+
+### よくあるエラー
+
+1. **型不整合**
+   ```
+   Type 'string' is not assignable to type 'number'
+   ```
+   - 対処: バックエンドとフロントエンドの型定義を再確認
+
+2. **オプショナル型エラー**
+   ```
+   Property 'distance' may be undefined
+   ```
+   - 対処: オプショナルチェイニング `?.` を使用
+
+3. **Date変換エラー**
+   ```
+   Invalid Date
+   ```
+   - 対処: ISO形式の文字列か確認、`new Date()` の前にバリデーション
+
+## 使用例
+
+### 例1: 新しいフィールド追加（馬体重）
+
+```
+入力:
+バックエンドに weight, weight_diff フィールドを追加
+
+出力:
+
+// API型に追加
+export interface ApiRunner {
+  // ... 既存フィールド
+  weight?: number;       // 追加
+  weight_diff?: number;  // 追加
+}
+
+// 表示用型に追加
+export interface Runner {
+  // ... 既存フィールド
+  weight?: number;
+  weightDiff?: number;   // camelCase変換
+}
+
+// マッピング関数更新
+export function mapApiRunnerToRunner(apiRunner: ApiRunner): Runner {
+  return {
+    // ... 既存マッピング
+    weight: apiRunner.weight,
+    weightDiff: apiRunner.weight_diff,
+  };
+}
+```
+
+### 例2: ネストした型のマッピング
+
+```
+バックエンドレスポンス:
+{
+  "race": { ... },
+  "runners": [
+    {
+      "horse_number": 1,
+      "pedigree": {
+        "sire_name": "ディープインパクト",
+        "dam_name": "ウインドインハーヘア"
+      }
+    }
+  ]
+}
+
+生成される型:
+
+export interface ApiPedigree {
+  sire_name: string;
+  dam_name: string;
+}
+
+export interface ApiRunner {
+  horse_number: number;
+  pedigree?: ApiPedigree;
+}
+
+export interface Pedigree {
+  sireName: string;
+  damName: string;
+}
+
+export interface Runner {
+  number: number;
+  pedigree?: Pedigree;
+}
+
+function mapApiPedigreeTopedigree(api: ApiPedigree): Pedigree {
+  return {
+    sireName: api.sire_name,
+    damName: api.dam_name,
+  };
+}
+```
+
+## 参照ファイル
+
+- **バックエンドHandler**: `main/backend/src/api/handlers/races.py`
+- **型定義**: `main/frontend/src/types/index.ts`
+- **APIクライアント**: `main/frontend/src/api/client.ts`
+
+## 注意事項
+
+- **API型は変更しない**: バックエンドと完全一致を保つ
+- **マッピング関数でのみ変換**: 表示用型への変換はマッピング関数で
+- **型安全性**: `npm run typecheck` で必ず確認
+- **命名規則**: camelCase変換ルールを統一

--- a/.claude/agents/tdd-generator.md
+++ b/.claude/agents/tdd-generator.md
@@ -1,0 +1,370 @@
+---
+name: tdd-generator
+description: TDD自動実行（Red → Green → Refactor サイクル）でテストファースト実装
+version: 1.0.0
+type: agent
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+# TDD自動実行サブエージェント
+
+## 概要
+
+テスト駆動開発（TDD）のRed → Green → Refactorサイクルを自動実行するサブエージェントです。テストを先に書いてから実装し、Mock更新漏れをゼロにすることを目標とします。
+
+このエージェントは独立したコンテキストで動作し、メイン会話を汚染せずにTDDサイクルを実行します。
+
+## 実行タイミング
+
+以下の状況で本エージェントを起動してください:
+
+- 新しいユースケースを実装する時
+- 新しいドメインエンティティを追加する時
+- 既存機能に重要な変更を加える時
+- リファクタリングする時（既存テストが通ることを保証）
+
+## TDDサイクル
+
+### フェーズ1: Red（失敗するテストを書く）
+
+#### ステップ1: テスト仕様の理解
+
+実装する機能の要件を分析し、テストケースを列挙します。
+
+**テストケースの種類**:
+1. **Happy Path**: 正常系のテスト
+2. **Edge Case**: 境界値テスト
+3. **Error Case**: エラーケーステスト
+4. **Integration**: 統合テスト（必要に応じて）
+
+#### ステップ2: テストファイル作成
+
+**ディレクトリ構造**:
+```
+main/backend/tests/
+├── domain/
+│   ├── entities/        # エンティティのテスト
+│   ├── value_objects/   # 値オブジェクトのテスト
+│   ├── services/        # ドメインサービスのテスト
+│   └── ports/           # ポートのテスト
+├── application/
+│   └── use_cases/       # ユースケースのテスト
+├── infrastructure/
+│   ├── providers/       # プロバイダーのテスト
+│   └── repositories/    # リポジトリのテスト
+└── api/
+    └── handlers/        # APIハンドラーのテスト
+```
+
+**テストファイル命名規則**:
+- `test_<モジュール名>.py`
+- クラステストの場合: `TestGetRaceDetailUseCase` のようにクラス名を `Test` プレフィックス付きで
+
+#### ステップ3: Mockプロバイダー作成
+
+テスト用のMock実装を作成します。
+
+**Mockパターン**:
+```python
+class MockRaceDataProvider(RaceDataProvider):
+    """テスト用のモック実装."""
+
+    def __init__(self) -> None:
+        self._races: dict[str, RaceData] = {}
+        self._runners: dict[str, list[RunnerData]] = {}
+
+    def add_race(self, race: RaceData) -> None:
+        """テスト用にレースを追加."""
+        self._races[race.race_id] = race
+
+    def add_runners(self, race_id: str, runners: list[RunnerData]) -> None:
+        """テスト用に出走馬を追加."""
+        self._runners[race_id] = runners
+
+    def get_race(self, race_id: RaceId) -> RaceData | None:
+        return self._races.get(str(race_id))
+
+    # ... その他の必須メソッド実装（デフォルト値を返す）
+```
+
+**重要な原則**:
+- すべての抽象メソッドを実装
+- テスト用のヘルパーメソッド（`add_*`）を提供
+- デフォルト値（`None`, `[]`, `{}`）を返す
+
+#### ステップ4: テストコード作成
+
+AAA（Arrange-Act-Assert）パターンでテストを書きます。
+
+**テストパターン**:
+```python
+def test_レースIDでレース詳細を取得できる(self) -> None:
+    """レースIDでレース詳細を取得できることを確認."""
+    # Arrange（準備）
+    provider = MockRaceDataProvider()
+    race = RaceData(
+        race_id="2024060111",
+        race_name="日本ダービー",
+        race_number=11,
+        venue="東京",
+        start_time=datetime(2024, 6, 1, 15, 40),
+        betting_deadline=datetime(2024, 6, 1, 15, 35),
+        track_condition="良",
+    )
+    provider.add_race(race)
+    use_case = GetRaceDetailUseCase(provider)
+
+    # Act（実行）
+    result = use_case.execute(RaceId("2024060111"))
+
+    # Assert（検証）
+    assert result is not None
+    assert result.race.race_name == "日本ダービー"
+```
+
+**命名規則**:
+- テスト名は日本語OK（`test_レースIDでレース詳細を取得できる`）
+- またはスネークケース（`test_get_race_detail_by_race_id`）
+- 何をテストしているか明確に
+
+#### ステップ5: Red確認（テスト失敗）
+
+テストを実行して、意図的に失敗することを確認します。
+
+**コマンド**:
+```bash
+cd main/backend
+pytest tests/application/use_cases/test_get_race_detail.py -v
+```
+
+**期待される出力**:
+```
+FAILED tests/application/use_cases/test_get_race_detail.py::test_レースIDでレース詳細を取得できる
+ModuleNotFoundError: No module named 'src.application.use_cases.get_race_detail'
+```
+
+### フェーズ2: Green（テストを通す最小限の実装）
+
+#### ステップ6: 最小限の実装
+
+テストが通る最小限のコードを書きます。
+
+**実装パターン（ユースケース）**:
+```python
+"""レース詳細取得ユースケース."""
+from dataclasses import dataclass
+
+from src.domain.identifiers import RaceId
+from src.domain.ports import RaceData, RaceDataProvider, RunnerData
+
+
+@dataclass(frozen=True)
+class GetRaceDetailResult:
+    """レース詳細取得結果."""
+
+    race: RaceData
+    runners: list[RunnerData]
+
+
+class GetRaceDetailUseCase:
+    """レース詳細取得ユースケース."""
+
+    def __init__(self, provider: RaceDataProvider) -> None:
+        self._provider = provider
+
+    def execute(self, race_id: RaceId) -> GetRaceDetailResult | None:
+        """レース詳細を取得する."""
+        race = self._provider.get_race(race_id)
+        if race is None:
+            return None
+
+        runners = self._provider.get_runners(race_id)
+        return GetRaceDetailResult(race=race, runners=runners)
+```
+
+**重要な原則**:
+- 過剰な実装はしない（YAGNI - You Aren't Gonna Need It）
+- テストが通る最小限のコード
+- frozen dataclass でイミュータブル性を保証
+
+#### ステップ7: Green確認（テスト成功）
+
+テストを実行して成功することを確認します。
+
+**コマンド**:
+```bash
+pytest tests/application/use_cases/test_get_race_detail.py -v
+```
+
+**期待される出力**:
+```
+tests/application/use_cases/test_get_race_detail.py::test_レースIDでレース詳細を取得できる PASSED
+```
+
+#### ステップ8: Mock実装の更新
+
+本番用のMock実装（`MockRaceDataProvider`）も同時に更新します。
+
+**更新対象**:
+- `main/backend/src/infrastructure/providers/mock_race_data_provider.py`
+
+**チェック項目**:
+- 新しいメソッドを実装したか
+- 新しいデータクラスのサンプル生成を追加したか
+- 再現可能なデータ生成（`_stable_hash`）を使用しているか
+
+### フェーズ3: Refactor（リファクタリング）
+
+#### ステップ9: コード品質の改善
+
+テストが通った状態で、コードの品質を改善します。
+
+**リファクタリング観点**:
+1. **DRY（Don't Repeat Yourself）**: 重複コードの削除
+2. **命名**: より明確な変数名・関数名
+3. **型ヒント**: 型の明示
+4. **ドキュメント**: docstringの充実
+5. **パフォーマンス**: 不要な計算の削除
+
+**重要**: リファクタリング後も必ずテストを実行
+
+#### ステップ10: エッジケース・エラーケースのテスト追加
+
+正常系以外のテストも追加します。
+
+**追加テスト例**:
+```python
+def test_存在しないレースIDでNoneを返す(self) -> None:
+    """存在しないレースIDでNoneが返ることを確認."""
+    provider = MockRaceDataProvider()
+    use_case = GetRaceDetailUseCase(provider)
+
+    result = use_case.execute(RaceId("nonexistent"))
+
+    assert result is None
+
+def test_出走馬がいないレースでも詳細を取得できる(self) -> None:
+    """出走馬がいないレースでも詳細を取得できることを確認."""
+    provider = MockRaceDataProvider()
+    race = RaceData(...)
+    provider.add_race(race)
+    use_case = GetRaceDetailUseCase(provider)
+
+    result = use_case.execute(RaceId("2024060111"))
+
+    assert result is not None
+    assert result.runners == []
+```
+
+#### ステップ11: 全テスト実行
+
+すべてのテストが通ることを確認します。
+
+**コマンド**:
+```bash
+pytest tests/ -v
+```
+
+## 出力形式
+
+### TDDサイクル開始時
+
+```
+🔴 Red フェーズ開始
+
+実装する機能: レース詳細取得ユースケース
+
+テストケース:
+1. ✅ Happy Path: レースIDでレース詳細を取得できる
+2. ✅ Edge Case: 存在しないレースIDでNoneを返す
+3. ✅ Edge Case: 出走馬がいないレースでも詳細を取得できる
+
+テストファイル作成: tests/application/use_cases/test_get_race_detail.py
+```
+
+### Red → Green 移行時
+
+```
+🟢 Green フェーズ開始
+
+テスト結果:
+FAILED tests/application/use_cases/test_get_race_detail.py::test_レースIDでレース詳細を取得できる
+ModuleNotFoundError: No module named 'src.application.use_cases.get_race_detail'
+
+実装する最小限のコード:
+- src/application/use_cases/get_race_detail.py
+```
+
+### Green → Refactor 移行時
+
+```
+🔵 Refactor フェーズ開始
+
+テスト結果: 全て成功 ✅
+
+リファクタリング観点:
+1. 命名の改善
+2. docstringの追加
+3. エッジケースのテスト追加
+```
+
+### TDDサイクル完了時
+
+```
+✅ TDDサイクル完了
+
+実装完了: GetRaceDetailUseCase
+
+テスト結果: 3/3 成功
+- test_レースIDでレース詳細を取得できる ✅
+- test_存在しないレースIDでNoneを返す ✅
+- test_出走馬がいないレースでも詳細を取得できる ✅
+
+更新ファイル:
+- tests/application/use_cases/test_get_race_detail.py
+- src/application/use_cases/get_race_detail.py
+- src/infrastructure/providers/mock_race_data_provider.py (Mock更新)
+
+次のアクション:
+- [ ] コミット: git commit -m "feat: レース詳細取得ユースケースを実装"
+- [ ] 統合テスト確認
+```
+
+## エラーハンドリング
+
+### よくあるエラー
+
+1. **ImportError: モジュールが見つからない**
+   - 対処: `__init__.py` ファイルを確認
+
+2. **AssertionError: 想定と異なる結果**
+   - 対処: テストデータとソースコードを再確認
+
+3. **Mock更新漏れ**
+   - 対処: `MockRaceDataProvider` に新メソッドを追加
+
+4. **型エラー**
+   - 対処: 型ヒントを確認、`mypy` で型チェック
+
+## 参照ファイル
+
+実装時は以下のファイルを参照:
+
+- **テスト例**: `main/backend/tests/application/use_cases/test_get_race_detail.py`
+- **ユースケース例**: `main/backend/src/application/use_cases/get_race_detail.py`
+- **Mock実装**: `main/backend/src/infrastructure/providers/mock_race_data_provider.py`
+- **ドメインモデル**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/`
+
+## 注意事項
+
+- **TDD原則を厳守**: テストを先に書く、実装は最小限
+- **イミュータブル**: データクラスは `frozen=True`
+- **DDD原則**: ドメインロジックはエンティティ・値オブジェクトに配置
+- **Mock更新**: 本番Mockも必ず更新
+- **全テスト実行**: リファクタリング後は必ず全テスト実行

--- a/.claude/skills/api-extend/SKILL.md
+++ b/.claude/skills/api-extend/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: api-extend
+description: API拡張ワークフロー（ports → provider → handler → Mock → テスト → フロント型 → UI）を自動化
+version: 1.0.0
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+skill_type: workflow
+auto_invoke: false
+---
+
+# API拡張ワークフロー
+
+## 概要
+
+新しいAPIフィールドやエンドポイントを追加する際の定型フローを自動化します。DDD（ドメイン駆動設計）とクリーンアーキテクチャの原則に従い、以下の8ステップを実行します:
+
+1. **ports定義** - ドメイン層のインターフェース定義
+2. **provider実装** - JRA-VAN APIプロバイダー実装
+3. **Mock実装** - モックプロバイダー実装
+4. **handler実装** - APIハンドラー（Lambda関数）
+5. **テスト作成/更新** - TDDに基づくテストコード
+6. **フロント型定義** - TypeScript型とマッピング関数
+7. **APIクライアント** - フロントエンドAPIクライアント更新
+8. **UI実装** - React コンポーネント更新
+
+## 入力形式
+
+スキル呼び出し時に以下の情報を提供してください:
+
+```
+/api-extend
+
+追加内容:
+- データクラス名: <DataClass名>（例: TrainingData）
+- フィールド:
+  - <field_name>: <type> - <説明>
+  - <field_name>: <type> - <説明>
+- エンドポイント（新規の場合）: GET /path/{param}
+- 既存エンドポイントへの追加（の場合）: <エンドポイント名>
+```
+
+## 実行プロセス
+
+### ステップ1: ports定義（ドメイン層）
+
+**ファイル**: `main/backend/src/domain/ports/race_data_provider.py`
+
+**パターン**:
+```python
+@dataclass(frozen=True)
+class <DataClass>:
+    """<説明>."""
+
+    field_name: type
+    field_name: type | None = None  # オプショナルフィールド
+
+class RaceDataProvider(ABC):
+    @abstractmethod
+    def get_<method_name>(self, <params>) -> <ReturnType>:
+        """<説明>."""
+        pass
+```
+
+**重要な規則**:
+- すべてのデータクラスは `@dataclass(frozen=True)` でイミュータブル
+- abstractmethodには必ず `pass` を記述
+- 型ヒントは必須（`str | None` 形式）
+
+### ステップ2: JRA-VAN Provider実装
+
+**ファイル**: `main/backend/src/infrastructure/providers/jravan_race_data_provider.py`
+
+**パターン**:
+```python
+def get_<method_name>(self, <params>) -> <ReturnType>:
+    """<説明>."""
+    try:
+        response = self._session.get(
+            f"{self._base_url}/<endpoint>",
+            params={"param": value} if needs_params else {},
+            timeout=self._timeout,
+        )
+        if response.status_code == 404:
+            return None  # または []
+        response.raise_for_status()
+
+        # リストの場合
+        data = response.json()
+        return [self._to_<data_class>(d) for d in data]
+
+        # 単一オブジェクトの場合
+        return self._to_<data_class>(response.json())
+    except requests.RequestException as e:
+        logger.warning(f"Could not get <resource>: {e}")
+        return None  # または []
+
+def _to_<data_class>(self, data: dict) -> <DataClass>:
+    """API レスポンスを <DataClass> に変換する."""
+    return <DataClass>(
+        field_name=data["field_name"],
+        optional_field=data.get("optional_field"),
+    )
+```
+
+**重要な規則**:
+- 404エラーは `None` または空リスト `[]` を返す
+- その他のエラーは警告ログを出力してデフォルト値を返す
+- 必ず `_to_<data_class>` 変換メソッドを実装
+- `data.get("key")` でオプショナルフィールドを取得
+
+### ステップ3: Mock Provider実装
+
+**ファイル**: `main/backend/src/infrastructure/providers/mock_race_data_provider.py`
+
+**パターン**:
+```python
+def get_<method_name>(self, <params>) -> <ReturnType>:
+    """<説明>."""
+    import random
+
+    random.seed(_stable_hash(str(<unique_key>)) % (2**32))
+
+    # データを生成
+    results = []
+    for i in range(<count>):
+        data = <DataClass>(
+            field_name=random.choice(self.SAMPLE_DATA),
+            numeric_field=random.randint(min, max),
+            optional_field=random.choice([...]) if needed else None,
+        )
+        results.append(data)
+
+    return results
+```
+
+**重要な規則**:
+- 必ず `_stable_hash()` でシード固定（再現可能なデータ生成）
+- クラス定数として `SAMPLE_DATA` を定義
+- ランダム生成でもリアルなデータ分布を意識
+
+### ステップ4: API Handler実装
+
+**ファイル**: `main/backend/src/api/handlers/races.py`
+
+**レスポンス構築パターン**:
+```python
+def get_<endpoint>(event: dict, context: Any) -> dict:
+    """<説明>.
+
+    GET /<path>?param=value
+
+    Query/Path Parameters:
+        param: 説明
+
+    Returns:
+        レスポンス説明
+    """
+    # パラメータ取得
+    param = get_query_parameter(event, "param")
+    # または
+    param = get_path_parameter(event, "param")
+
+    if not param:
+        return bad_request_response("param is required")
+
+    # ユースケース実行
+    provider = Dependencies.get_race_data_provider()
+    result = provider.get_<method>(param)
+
+    if result is None:
+        return not_found_response("<Resource>")
+
+    # レスポンス構築
+    response_data = [
+        {
+            "field_name": item.field_name,
+            "optional_field": item.optional_field,
+        }
+        for item in result
+    ]
+
+    return success_response({"data": response_data})
+```
+
+**重要な規則**:
+- snake_case → camelCase 変換は不要（バックエンドはsnake_case統一）
+- 必ず入力バリデーション
+- エラーレスポンスは `bad_request_response()`, `not_found_response()` を使用
+
+### ステップ5: テスト作成/更新
+
+**ファイル**: `main/backend/tests/` 配下の適切な場所
+
+**テストパターン**:
+```python
+def test_get_<method_name>():
+    """<説明>."""
+    # Arrange
+    provider = MockRaceDataProvider()
+
+    # Act
+    result = provider.get_<method_name>(<params>)
+
+    # Assert
+    assert result is not None
+    assert len(result) > 0
+    assert result[0].field_name == expected_value
+```
+
+**重要な規則**:
+- AAA パターン（Arrange, Act, Assert）
+- Mockプロバイダーを使用してテスト
+- 境界値・エラーケースもテスト
+
+### ステップ6: フロントエンド型定義
+
+**ファイル**: `main/frontend/src/types/index.ts`
+
+**パターン**:
+```typescript
+// API形式（バックエンドレスポンス）
+export interface Api<DataClass> {
+  field_name: string;
+  optional_field?: number;
+}
+
+// フロントエンド表示用
+export interface <DataClass> {
+  fieldName: string;
+  optionalField?: number;
+}
+
+// 変換関数
+export function mapApi<DataClass>To<DataClass>(api: Api<DataClass>): <DataClass> {
+  return {
+    fieldName: api.field_name,
+    optionalField: api.optional_field,
+  };
+}
+```
+
+**重要な規則**:
+- API型は `Api<Name>` プレフィックス（snake_case）
+- フロントエンド型は camelCase
+- 必ずマッピング関数を提供
+
+### ステップ7: APIクライアント更新
+
+**ファイル**: `main/frontend/src/api/client.ts`
+
+**パターン**:
+```typescript
+async get<Resource>(<params>): Promise<ApiResponse<<DataClass>>> {
+  const response = await this.request<Api<DataClass>Response>(
+    `/endpoint/${encodeURIComponent(param)}`
+  );
+
+  if (!response.success || !response.data) {
+    return { success: false, error: response.error };
+  }
+
+  return {
+    success: true,
+    data: mapApi<DataClass>To<DataClass>(response.data),
+  };
+}
+```
+
+**重要な規則**:
+- URLパラメータは `encodeURIComponent()` でエンコード
+- レスポンス型チェックを必ず実施
+- エラーハンドリングを統一
+
+### ステップ8: UI実装ガイダンス
+
+**対象ファイル**: `main/frontend/src/pages/*Page.tsx`, `main/frontend/src/components/*`
+
+**提供内容**:
+- どのコンポーネントを更新すべきか
+- 新しいフィールドの表示例（Tailwind CSS）
+- 状態管理パターン（useState, useEffect）
+
+## 出力形式
+
+以下の形式で進捗を報告:
+
+```
+✅ ステップ1: ports定義完了
+  - <DataClass>を追加
+  - get_<method>メソッドを追加
+
+✅ ステップ2: JRA-VAN Provider実装完了
+  - get_<method>を実装
+  - _to_<data_class>変換メソッドを実装
+
+✅ ステップ3: Mock Provider実装完了
+  - サンプルデータ生成ロジックを実装
+
+✅ ステップ4: API Handler実装完了
+  - GET /<endpoint> エンドポイントを実装
+
+✅ ステップ5: テスト作成完了
+  - test_get_<method> を追加
+
+✅ ステップ6: フロントエンド型定義完了
+  - Api<DataClass>, <DataClass> 型を追加
+  - マッピング関数を追加
+
+✅ ステップ7: APIクライアント更新完了
+  - get<Resource>メソッドを追加
+
+⏳ ステップ8: UI実装ガイダンス
+  - 更新対象: <component_path>
+  - 表示例コードを提供
+
+次のアクション:
+- [ ] テスト実行（pytest）
+- [ ] フロントエンドビルド確認（npm run build）
+- [ ] デプロイ前チェック（./scripts/pre-deploy-check.sh）
+```
+
+## エラーハンドリング
+
+### 頻出エラーと対処法
+
+1. **ImportError: frozen dataclassのimport漏れ**
+   - 対処: `from dataclasses import dataclass` を確認
+
+2. **型エラー: Optional型の扱い**
+   - 対処: `str | None` 形式を使用（`Optional[str]` は使わない）
+
+3. **Mock更新漏れ**
+   - 対処: 必ず Mock Provider も同時に更新
+
+4. **フロントエンド型不整合**
+   - 対処: `npm run typecheck` で確認
+
+## 使用例
+
+### 例1: 馬の血統情報を追加
+
+```
+/api-extend
+
+追加内容:
+- データクラス名: PedigreeData
+- フィールド:
+  - horse_id: str - 馬ID
+  - horse_name: str | None - 馬名
+  - sire_name: str | None - 父馬名
+  - dam_name: str | None - 母馬名
+  - broodmare_sire: str | None - 母父馬名
+- エンドポイント: GET /horses/{horse_id}/pedigree
+```
+
+### 例2: 既存APIに馬体重フィールドを追加
+
+```
+/api-extend
+
+追加内容:
+- データクラス名: WeightData
+- フィールド:
+  - weight: int - 馬体重(kg)
+  - weight_diff: int - 前走比増減
+- 既存エンドポイントへの追加: GET /races/{race_id} のrunnersに追加
+```
+
+## 参照コード
+
+実装時は以下のファイルを参照:
+
+- **ports定義**: `main/backend/src/domain/ports/race_data_provider.py`
+- **JRA-VAN Provider**: `main/backend/src/infrastructure/providers/jravan_race_data_provider.py`
+- **Mock Provider**: `main/backend/src/infrastructure/providers/mock_race_data_provider.py`
+- **API Handler**: `main/backend/src/api/handlers/races.py`
+- **フロント型**: `main/frontend/src/types/index.ts`
+- **APIクライアント**: `main/frontend/src/api/client.ts`
+
+## 注意事項
+
+- **TDD原則**: テストを先に書いてから実装（Red → Green → Refactor）
+- **イミュータブル**: すべてのデータクラスは `frozen=True`
+- **DDD原則**: ドメインロジックはポート・アダプターパターンを遵守
+- **型安全性**: フロントエンドは必ず `npm run typecheck` で確認
+- **git worktree**: 作業は必ず feature ブランチで（main直接push禁止）

--- a/.claude/skills/copilot-review/SKILL.md
+++ b/.claude/skills/copilot-review/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: copilot-review
+description: GitHub Copilot PRレビュー対応ワークフロー（コメント取得→修正→返信→解決）
+version: 1.0.0
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+skill_type: workflow
+auto_invoke: false
+---
+
+# Copilot PRレビュー対応ワークフロー
+
+## 概要
+
+GitHub Copilot によるPRレビューコメントへの対応を効率化します。レビューコメントの取得から修正、返信、スレッド解決までを自動化し、PRレビュー対応時間を15分→3分に短縮（80%削減）します。
+
+**重要**: ブランチ保護ルールにより、全てのコメントを解決しないとマージできません。
+
+## 入力形式
+
+スキル呼び出し時にPR番号を指定してください:
+
+```
+/copilot-review <PR番号>
+```
+
+または
+
+```
+/copilot-review
+
+PR番号: <番号>
+```
+
+## 実行プロセス
+
+### ステップ1: レビューコメント取得
+
+GitHub APIを使用してPRのレビューコメントを取得します。
+
+**コマンド**:
+```bash
+gh api repos/foie0222/baken-kaigi/pulls/<PR番号>/comments \
+  --jq '.[] | {id, path, line, body, user: .user.login}'
+```
+
+**出力例**:
+```json
+{
+  "id": 123456789,
+  "path": "backend/src/domain/ports/race_data_provider.py",
+  "line": 25,
+  "body": "Consider adding type hints for the return value",
+  "user": "copilot"
+}
+```
+
+**判断基準**:
+- Copilotによるコメント（`user: "copilot"`）のみを対象
+- 人間のレビュアーコメントは別途確認を促す
+
+### ステップ2: コメント内容の分析と優先度付け
+
+レビューコメントを以下のカテゴリーに分類:
+
+1. **Critical（即座に対応）**:
+   - セキュリティ脆弱性
+   - バグの可能性
+   - テスト不足
+
+2. **High（優先対応）**:
+   - 型ヒント不足
+   - エラーハンドリング不足
+   - コード品質問題
+
+3. **Medium（推奨対応）**:
+   - 命名規則
+   - コメント不足
+   - リファクタリング提案
+
+4. **Low（任意対応）**:
+   - コードスタイル
+   - 軽微な改善提案
+
+### ステップ3: 対応方針の提案
+
+各コメントに対して以下のいずれかを提案:
+
+1. **修正する**: コメントの指摘を受け入れて修正
+2. **説明を返信**: 現状の実装理由を説明し、修正不要と判断
+3. **代替案を提示**: 別のアプローチを提案
+
+**提案フォーマット**:
+```
+📝 レビューコメント #1 [Critical]
+ファイル: backend/src/domain/ports/race_data_provider.py:25
+指摘: Consider adding type hints for the return value
+
+提案: 修正する
+理由: 型ヒントはコードの可読性と保守性を向上させる
+修正内容: 戻り値の型ヒントを追加
+```
+
+### ステップ4: 修正実施
+
+ユーザーの承認後、Editツールを使用して修正を実施します。
+
+**修正パターン**:
+
+#### パターン1: 型ヒント追加
+```python
+# Before
+def get_race(self, race_id):
+    pass
+
+# After
+def get_race(self, race_id: RaceId) -> RaceData | None:
+    pass
+```
+
+#### パターン2: エラーハンドリング追加
+```python
+# Before
+data = response.json()
+return data["value"]
+
+# After
+try:
+    data = response.json()
+    return data.get("value")
+except (KeyError, ValueError) as e:
+    logger.error(f"Failed to parse response: {e}")
+    return None
+```
+
+#### パターン3: テスト追加
+```python
+def test_get_race_not_found():
+    """存在しないレースIDの場合Noneを返す."""
+    # Arrange
+    provider = MockRaceDataProvider()
+    race_id = RaceId("invalid_id")
+
+    # Act
+    result = provider.get_race(race_id)
+
+    # Assert
+    assert result is None
+```
+
+### ステップ5: コミット・プッシュ
+
+修正をコミットしてプッシュします。
+
+**コマンド**:
+```bash
+git add <修正ファイル>
+git commit -m "fix: Copilotレビュー指摘対応 - <概要>"
+git push
+```
+
+**コミットメッセージ例**:
+- `fix: Copilotレビュー指摘対応 - 型ヒント追加`
+- `fix: Copilotレビュー指摘対応 - エラーハンドリング改善`
+- `test: Copilotレビュー指摘対応 - テストケース追加`
+
+### ステップ6: コメントに返信
+
+修正内容または説明をコメントに返信します。
+
+**コマンド**:
+```bash
+gh api repos/foie0222/baken-kaigi/pulls/<PR番号>/comments/<コメントID>/replies \
+  -X POST \
+  -f body='<返信内容>'
+```
+
+**返信テンプレート**:
+
+#### 修正した場合:
+```
+✅ 修正しました。
+
+変更内容:
+- <変更1>
+- <変更2>
+
+コミット: <コミットハッシュ>
+```
+
+#### 説明で対応する場合:
+```
+📝 現在の実装理由
+
+<理由の説明>
+
+そのため、この指摘については現状維持とさせていただきます。
+```
+
+### ステップ7: スレッド解決
+
+修正完了後、レビュースレッドを解決します。
+
+**ステップ7-1: スレッドID取得**
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "foie0222", name: "baken-kaigi") {
+    pullRequest(number: <PR番号>) {
+      reviewThreads(first: 20) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              databaseId
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+**ステップ7-2: スレッド解決**
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "<スレッドID>"}) {
+    thread {
+      isResolved
+    }
+  }
+}'
+```
+
+### ステップ8: 対応完了確認
+
+全てのコメントに対応したことを確認します。
+
+**確認コマンド**:
+```bash
+# 未解決のスレッド数を確認
+gh api graphql -f query='
+query {
+  repository(owner: "foie0222", name: "baken-kaigi") {
+    pullRequest(number: <PR番号>) {
+      reviewThreads(first: 20) {
+        nodes {
+          isResolved
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length'
+```
+
+**期待値**: `0`（全スレッド解決済み）
+
+## 出力形式
+
+```
+📊 Copilot レビュー対応サマリー
+
+PR番号: #<番号>
+レビューコメント総数: <件数>
+
+対応状況:
+✅ 修正済み: <件数>
+📝 説明返信: <件数>
+⏭️  スキップ: <件数>
+
+詳細:
+---
+📝 コメント #1 [Critical]
+ファイル: backend/src/domain/ports/race_data_provider.py:25
+指摘: Consider adding type hints for the return value
+対応: ✅ 修正済み
+返信: "型ヒントを追加しました。"
+---
+
+次のアクション:
+- [ ] 全スレッド解決確認（gh api graphqlで確認）
+- [ ] CI/CD成功確認
+- [ ] マージ実行
+```
+
+## エラーハンドリング
+
+### 頻出エラーと対処法
+
+1. **GraphQL API認証エラー**
+   ```
+   Error: HTTP 401: Unauthorized
+   ```
+   - 対処: `gh auth login` で再認証
+
+2. **スレッドIDが見つからない**
+   ```
+   Error: Invalid thread ID
+   ```
+   - 対処: GraphQLクエリで最新のスレッドIDを再取得
+
+3. **コメント返信に失敗**
+   ```
+   Error: Resource not accessible by integration
+   ```
+   - 対処: `gh` CLI の権限スコープを確認（`repo` スコープが必要）
+
+4. **マージブロック**
+   ```
+   Error: Required reviews not satisfied
+   ```
+   - 対処: 全スレッドが解決されているか確認
+
+## 命名規則/パターン
+
+### コミットメッセージ
+
+- `fix: Copilotレビュー指摘対応 - <具体的な修正内容>`
+- 複数ファイル修正の場合は概要を記載
+
+### 返信メッセージ
+
+- 簡潔に（3行以内）
+- 絵文字で状態を明示（✅, 📝, ⚠️）
+- コミットハッシュを含める
+
+## 使用例
+
+### 例1: 型ヒント不足の指摘に対応
+
+```
+/copilot-review 42
+
+📊 Copilot レビュー対応サマリー
+
+PR番号: #42
+レビューコメント総数: 3件
+
+対応状況:
+✅ 修正済み: 2件
+📝 説明返信: 1件
+
+詳細:
+---
+📝 コメント #1 [High]
+ファイル: backend/src/domain/ports/race_data_provider.py:25
+指摘: Consider adding type hints for the return value
+対応: ✅ 修正済み
+返信: "戻り値の型ヒントを追加しました。"
+コミット: abc1234
+---
+📝 コメント #2 [Medium]
+ファイル: backend/src/api/handlers/races.py:50
+指摘: Consider extracting this to a separate function
+対応: 📝 説明返信
+返信: "現状のロジックは十分シンプルであり、抽出するとかえって複雑になると判断しました。"
+---
+
+次のアクション:
+- [x] 全スレッド解決確認
+- [ ] CI/CD成功確認
+- [ ] マージ実行
+```
+
+### 例2: セキュリティ指摘への対応
+
+```
+/copilot-review 45
+
+📊 Copilot レビュー対応サマリー
+
+PR番号: #45
+レビューコメント総数: 1件
+
+対応状況:
+✅ 修正済み: 1件
+
+詳細:
+---
+📝 コメント #1 [Critical]
+ファイル: backend/src/api/handlers/races.py:30
+指摘: Potential SQL injection vulnerability
+対応: ✅ 修正済み
+返信: "パラメータ化クエリに変更し、SQLインジェクションを防止しました。"
+コミット: def5678
+---
+
+次のアクション:
+- [x] 全スレッド解決確認
+- [x] CI/CD成功確認
+- [ ] マージ実行
+```
+
+## 参照コマンド
+
+### GitHub CLI (gh) コマンド一覧
+
+```bash
+# PR一覧表示
+gh pr list
+
+# PR詳細表示
+gh pr view <PR番号>
+
+# レビューコメント取得
+gh api repos/foie0222/baken-kaigi/pulls/<PR番号>/comments
+
+# コメントに返信
+gh api repos/foie0222/baken-kaigi/pulls/<PR番号>/comments/<コメントID>/replies \
+  -X POST -f body='返信内容'
+
+# スレッド情報取得
+gh api graphql -f query='...'
+
+# スレッド解決
+gh api graphql -f query='mutation { resolveReviewThread(...) }'
+```
+
+### GraphQL クエリテンプレート
+
+#### 未解決スレッド一覧取得
+```graphql
+query {
+  repository(owner: "foie0222", name: "baken-kaigi") {
+    pullRequest(number: <PR番号>) {
+      reviewThreads(first: 20) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              body
+              path
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### スレッド解決
+```graphql
+mutation {
+  resolveReviewThread(input: {threadId: "<スレッドID>"}) {
+    thread {
+      isResolved
+    }
+  }
+}
+```
+
+## 注意事項
+
+- **ブランチ保護**: 全コメント解決しないとマージ不可
+- **CI/CD**: レビュー対応後も必ずCI/CDの成功を確認
+- **人間レビュー**: Copilot以外のレビューコメントは別途対応
+- **過剰な修正**: 指摘が不適切な場合は説明返信で対応（盲目的に修正しない）
+- **git worktree**: 作業は feature ブランチで実施

--- a/.claude/skills/ddd-check/SKILL.md
+++ b/.claude/skills/ddd-check/SKILL.md
@@ -1,0 +1,430 @@
+---
+name: ddd-check
+description: DDD設計原則チェッカー（AIDLC ドキュメントと実装コードの一貫性を検証）
+version: 1.0.0
+tools:
+  - Read
+  - Grep
+  - Glob
+skill_type: verification
+auto_invoke: false
+---
+
+# DDD設計原則チェッカー
+
+## 概要
+
+ドメイン駆動設計（DDD）の原則に従った実装がなされているかを検証します。AIDLC（AI-Driven Life Cycle）ドキュメントと実装コードの一貫性を確認し、ドメインモデル違反を早期に検出します。
+
+## 入力形式
+
+スキル呼び出し時に検証対象を指定できます:
+
+```
+/ddd-check
+```
+
+または特定のファイル/ディレクトリのみ検証:
+
+```
+/ddd-check --domain-only
+/ddd-check --file src/domain/entities/cart.py
+```
+
+## 実行プロセス
+
+### ステップ1: ユビキタス言語の整合性チェック
+
+**検証内容**:
+- `aidlc-docs/construction/unit_01_ai_dialog_public/docs/ubiquitous_language.md` で定義された用語がコード内で正しく使用されているか
+
+**確認ファイル**:
+```bash
+# ユビキタス言語定義を読む
+main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/ubiquitous_language.md
+
+# コードで使用されている用語を確認
+main/backend/src/domain/**/*.py
+```
+
+**チェック項目**:
+
+#### 1. コアドメイン用語の使用
+
+| 日本語 | 英語 | コード内での使用例 |
+|--------|------|-------------------|
+| 買い目 | BetSelection | `class BetSelection` (値オブジェクト) |
+| カート | Cart | `class Cart` (エンティティ) |
+| カートアイテム | CartItem | `class CartItem` (エンティティ) |
+| 相談セッション | ConsultationSession | `class ConsultationSession` (集約ルート) |
+| メッセージ | Message | `class Message` (エンティティ) |
+| データフィードバック | DataFeedback | `class DataFeedback` (値オブジェクト) |
+| 掛け金フィードバック | AmountFeedback | `class AmountFeedback` (値オブジェクト) |
+
+**検証方法**:
+```bash
+# 用語が正しく使用されているか確認
+grep -r "class BetSelection" main/backend/src/domain/value_objects/
+grep -r "class Cart" main/backend/src/domain/entities/
+```
+
+**違反パターン**:
+- ❌ `BettingSelection` (誤った用語)
+- ❌ `ShoppingCart` (別ドメインの用語混入)
+- ❌ `OrderItem` (ECサイトの用語混入)
+
+#### 2. サポートドメイン用語の使用
+
+| 日本語 | 英語 | 扱い |
+|--------|------|------|
+| レース | Race | 外部データ（Read Model） |
+| 開催場 | Venue | 外部データ |
+| 出走馬 | Runner | 外部データ |
+| 騎手 | Jockey | 外部データ |
+| オッズ | Odds | 外部データ |
+
+**検証方法**:
+- サポートドメインの概念はポート（`RaceDataProvider`）経由でのみ取得
+- ドメインエンティティとして内部実装してはいけない
+
+**違反パターン**:
+- ❌ `class Race(Entity)` をドメイン層に実装
+- ❌ `Race` クラスにビジネスロジックを追加
+
+### ステップ2: レイヤー分離の検証
+
+**ディレクトリ構造チェック**:
+```
+main/backend/src/
+├── domain/              # ドメイン層（ビジネスロジック）
+│   ├── entities/        # エンティティ（識別子を持つ）
+│   ├── value_objects/   # 値オブジェクト（イミュータブル）
+│   ├── services/        # ドメインサービス
+│   ├── ports/           # インターフェース（ポート）
+│   ├── identifiers/     # 識別子（ID型）
+│   └── enums/           # 列挙型
+├── application/         # アプリケーション層（ユースケース）
+│   └── use_cases/
+├── infrastructure/      # インフラ層（外部システム連携）
+│   ├── providers/       # プロバイダー（アダプター）
+│   └── repositories/
+└── api/                 # API層（Lambda ハンドラー）
+    └── handlers/
+```
+
+**検証ルール**:
+
+#### 依存関係の方向
+
+```
+API層 → アプリケーション層 → ドメイン層 ← インフラ層
+```
+
+**許可される依存**:
+- ✅ API層 → アプリケーション層
+- ✅ アプリケーション層 → ドメイン層
+- ✅ インフラ層 → ドメイン層（ポート実装）
+
+**禁止される依存**:
+- ❌ ドメイン層 → インフラ層
+- ❌ ドメイン層 → API層
+- ❌ アプリケーション層 → インフラ層（直接依存）
+
+**検証方法**:
+```bash
+# ドメイン層がインフラ層をインポートしていないか確認
+grep -r "from src.infrastructure" main/backend/src/domain/
+# → 何も見つからないはず
+
+# ドメイン層がAPI層をインポートしていないか確認
+grep -r "from src.api" main/backend/src/domain/
+# → 何も見つからないはず
+```
+
+### ステップ3: エンティティと値オブジェクトの検証
+
+#### エンティティのルール
+
+**必須条件**:
+1. 識別子（ID）を持つ
+2. ライフサイクルがある（生成→更新→削除）
+3. 同一性は識別子で判断（`__eq__` の実装）
+
+**検証パターン**:
+```python
+@dataclass
+class Cart:
+    """カートエンティティ."""
+
+    cart_id: CartId  # ✅ 識別子を持つ
+    items: list[CartItem]  # ✅ 可変な状態
+
+    def add_item(self, item: CartItem) -> None:
+        """アイテムを追加."""  # ✅ 振る舞いを持つ
+        self.items.append(item)
+```
+
+**違反パターン**:
+```python
+# ❌ frozen=True はエンティティに使わない（値オブジェクト用）
+@dataclass(frozen=True)
+class Cart:
+    cart_id: CartId
+    items: list[CartItem]
+```
+
+#### 値オブジェクトのルール
+
+**必須条件**:
+1. イミュータブル（`frozen=True`）
+2. 識別子を持たない
+3. 等価性は値で判断
+
+**検証パターン**:
+```python
+@dataclass(frozen=True)
+class BetSelection:
+    """買い目（値オブジェクト）."""
+
+    bet_type: BetType
+    horse_numbers: HorseNumbers
+    amount: Money
+
+    # ✅ 振る舞いは新しいインスタンスを返す
+    def change_amount(self, new_amount: Money) -> "BetSelection":
+        return BetSelection(
+            bet_type=self.bet_type,
+            horse_numbers=self.horse_numbers,
+            amount=new_amount,
+        )
+```
+
+**違反パターン**:
+```python
+# ❌ frozen=True がない
+@dataclass
+class BetSelection:
+    bet_type: BetType
+    horse_numbers: HorseNumbers
+    amount: Money
+
+# ❌ 値オブジェクトが識別子を持つ
+@dataclass(frozen=True)
+class BetSelection:
+    selection_id: str  # ❌ 識別子は不要
+    bet_type: BetType
+```
+
+### ステップ4: 集約の境界検証
+
+**集約のルール**:
+1. 集約ルートを通じてのみ内部エンティティにアクセス
+2. トランザクション境界 = 集約境界
+3. 集約間の参照は識別子のみ
+
+**検証例**:
+
+#### 正しい集約設計
+
+```python
+@dataclass
+class ConsultationSession:
+    """相談セッション（集約ルート）."""
+
+    session_id: SessionId  # 識別子
+    user_id: UserId
+    messages: list[Message]  # 内部エンティティ
+
+    def add_message(self, message: Message) -> None:
+        """メッセージを追加."""  # ✅ 集約ルート経由
+        self.messages.append(message)
+```
+
+**違反パターン**:
+```python
+# ❌ 集約を越えた直接参照
+@dataclass
+class Message:
+    message_id: MessageId
+    consultation_session: ConsultationSession  # ❌ 集約全体を参照
+```
+
+**正しいパターン**:
+```python
+# ✅ 識別子のみで参照
+@dataclass
+class Message:
+    message_id: MessageId
+    session_id: SessionId  # ✅ 識別子のみ
+```
+
+### ステップ5: ドメインサービスの検証
+
+**ドメインサービスの条件**:
+1. ステートレス（状態を持たない）
+2. 複数のエンティティにまたがるロジック
+3. エンティティや値オブジェクトに置けないロジック
+
+**検証パターン**:
+```python
+class FeedbackGenerator:
+    """フィードバック生成ドメインサービス."""
+
+    def __init__(self, ai_client: AiClient) -> None:
+        self._ai_client = ai_client  # ✅ 依存性注入
+
+    def generate_feedback(
+        self,
+        bet_selection: BetSelection,
+        race_data: RaceData,
+        runner_data: list[RunnerData],
+    ) -> DataFeedback:
+        """買い目のフィードバックを生成."""
+        # ✅ 複数のドメインオブジェクトを使用するロジック
+        ...
+```
+
+**違反パターン**:
+```python
+# ❌ 状態を持つドメインサービス
+class FeedbackGenerator:
+    def __init__(self) -> None:
+        self._cache: dict = {}  # ❌ 状態を持つ
+
+# ❌ エンティティに置けるロジックをサービスに配置
+class CartService:
+    def add_item(self, cart: Cart, item: CartItem) -> None:
+        cart.items.append(item)  # ❌ これはCartエンティティのメソッドにすべき
+```
+
+### ステップ6: ポート・アダプターパターンの検証
+
+**ポート（インターフェース）の検証**:
+
+```python
+# ✅ 正しいポート定義
+class RaceDataProvider(ABC):
+    """レースデータ取得インターフェース."""
+
+    @abstractmethod
+    def get_race(self, race_id: RaceId) -> RaceData | None:
+        pass  # ✅ インターフェースのみ
+
+# ✅ 正しいアダプター実装
+class JraVanRaceDataProvider(RaceDataProvider):
+    """JRA-VAN からデータ取得."""
+
+    def get_race(self, race_id: RaceId) -> RaceData | None:
+        # 外部API呼び出し
+        ...
+```
+
+**違反パターン**:
+```python
+# ❌ ポートに実装を含む
+class RaceDataProvider(ABC):
+    def get_race(self, race_id: RaceId) -> RaceData | None:
+        # ❌ デフォルト実装を含む
+        return None
+```
+
+## 出力形式
+
+### 全チェック通過時
+
+```
+✅ DDD設計原則チェック完了
+
+検証項目:
+- [✅] ユビキタス言語の整合性
+- [✅] レイヤー分離
+- [✅] エンティティと値オブジェクトの区別
+- [✅] 集約の境界
+- [✅] ドメインサービスの適切性
+- [✅] ポート・アダプターパターン
+
+🎉 DDD原則に従った実装がなされています。
+```
+
+### 違反検出時
+
+```
+🔴 DDD設計原則違反を検出
+
+検証項目:
+- [✅] ユビキタス言語の整合性
+- [🔴] レイヤー分離 - 1件の違反
+- [✅] エンティティと値オブジェクトの区別
+- [⚠️] 集約の境界 - 1件の警告
+- [✅] ドメインサービスの適切性
+- [✅] ポート・アダクターパターン
+
+---
+🔴 違反 #1: レイヤー依存関係違反
+
+ファイル: src/domain/entities/cart.py:15
+違反内容: ドメイン層がインフラ層をインポート
+
+コード:
+```python
+from src.infrastructure.repositories import CartRepository  # ❌
+```
+
+理由: ドメイン層はインフラ層に依存してはいけない
+
+修正案:
+1. CartRepository をポート（インターフェース）として domain/ports/ に定義
+2. domain層では CartRepository ポートを使用
+3. infrastructure層で CartRepository を実装
+
+---
+⚠️ 警告 #1: 集約の境界が曖昧
+
+ファイル: src/domain/entities/message.py:10
+警告内容: 集約を越えた直接参照
+
+コード:
+```python
+consultation_session: ConsultationSession  # ⚠️
+```
+
+理由: 集約間の参照は識別子のみが推奨
+
+推奨修正:
+```python
+session_id: SessionId  # ✅ 識別子のみで参照
+```
+
+---
+
+次のアクション:
+- [ ] 違反の修正
+- [ ] 警告の確認（必要に応じて修正）
+- [ ] 再検証: /ddd-check
+```
+
+## 参照ドキュメント
+
+### AIDLC ドキュメント
+
+- **ユビキタス言語**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/ubiquitous_language.md`
+- **エンティティ**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/entities.md`
+- **値オブジェクト**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/value_objects.md`
+- **集約**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/aggregates.md`
+- **ドメインサービス**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/domain_services.md`
+- **アーキテクチャ**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/architecture.md`
+
+### 実装コード
+
+- **ドメイン層**: `main/backend/src/domain/`
+- **アプリケーション層**: `main/backend/src/application/`
+- **インフラ層**: `main/backend/src/infrastructure/`
+- **API層**: `main/backend/src/api/`
+
+## 注意事項
+
+- **ユビキタス言語**: ドキュメントとコードで用語を統一
+- **レイヤー分離**: ドメイン層は外部に依存しない
+- **イミュータブル**: 値オブジェクトは必ず `frozen=True`
+- **集約境界**: トランザクション境界を意識
+- **ポート・アダプター**: 外部依存はインターフェース経由

--- a/.claude/skills/deploy-prep/SKILL.md
+++ b/.claude/skills/deploy-prep/SKILL.md
@@ -1,0 +1,451 @@
+---
+name: deploy-prep
+description: デプロイ前チェックスクリプトを実行し、エラーを解析・修正
+version: 1.0.0
+tools:
+  - Bash
+  - Read
+  - Edit
+  - Grep
+skill_type: verification
+auto_invoke: false
+---
+
+# デプロイ前チェック
+
+## 概要
+
+デプロイ前に必須のチェック項目（テスト・リント・CDK Synth）を自動実行し、エラーが発生した場合は原因を解析して修正を提案します。デプロイ失敗による手戻りをゼロにすることを目標とします。
+
+## 入力形式
+
+スキル呼び出し時にオプションを指定できます:
+
+```
+/deploy-prep
+```
+
+または特定のチェックのみ実行:
+
+```
+/deploy-prep --backend-only
+/deploy-prep --frontend-only
+/deploy-prep --cdk-only
+```
+
+## 実行プロセス
+
+### ステップ1: 環境確認
+
+デプロイ前チェックを実行できる環境か確認します。
+
+**確認項目**:
+- 現在のディレクトリが git worktree のルート
+- `main` ディレクトリが存在
+- `scripts/pre-deploy-check.sh` が存在
+
+**コマンド**:
+```bash
+# worktree 確認
+git worktree list
+
+# スクリプト存在確認
+ls -la main/scripts/pre-deploy-check.sh
+```
+
+### ステップ2: デプロイ前チェックスクリプト実行
+
+`scripts/pre-deploy-check.sh` を実行し、全チェック項目を検証します。
+
+**コマンド**:
+```bash
+cd main
+./scripts/pre-deploy-check.sh
+```
+
+**チェック内容**:
+1. **バックエンドテスト** (`pytest`)
+2. **フロントエンドリント** (`npm run lint`)
+3. **フロントエンドテスト** (`npm run test:run`)
+4. **CDK Synth確認** (`npx cdk synth`)
+
+### ステップ3: エラー解析
+
+各チェックでエラーが発生した場合、エラー種別を分析します。
+
+#### エラーカテゴリー
+
+##### 1. バックエンドテストエラー
+
+**エラーパターン**:
+```
+FAILED tests/domain/test_race.py::test_race_creation - AssertionError: assert None is not None
+```
+
+**原因分析**:
+- テストロジックの不備
+- Mock データの不整合
+- 型エラー
+- インポート漏れ
+
+**対処法**:
+1. 失敗したテストファイルを読む
+2. テストコードとソースコードを比較
+3. 修正を提案
+
+##### 2. フロントエンドリントエラー
+
+**エラーパターン**:
+```
+error  'React' is defined but never used  @typescript-eslint/no-unused-vars
+warning  Unexpected console statement  no-console
+```
+
+**原因分析**:
+- 未使用変数・インポート
+- console.log の残存
+- コーディングスタイル違反
+
+**対処法**:
+1. ESLint ルールに従って修正
+2. 自動修正可能な場合は `npm run lint -- --fix`
+
+##### 3. フロントエンドテストエラー
+
+**エラーパターン**:
+```
+FAIL src/components/RaceCard.test.tsx
+  ● RaceCard › renders race information
+    TypeError: Cannot read property 'name' of undefined
+```
+
+**原因分析**:
+- Propsの型不整合
+- Mockデータの不足
+- テストセットアップの不備
+
+**対処法**:
+1. テストファイルを読む
+2. コンポーネントとテストの整合性を確認
+3. Mock データを修正
+
+##### 4. CDK Synthエラー
+
+**エラーパターン**:
+```
+Error: Cannot find module '@aws-cdk/aws-lambda'
+Snapshot verification failed. Re-run with --force
+```
+
+**原因分析**:
+- 依存関係の不足
+- CDK スナップショット不一致
+- スタック定義の誤り
+
+**対処法**:
+1. 依存関係インストール: `npm install`
+2. スナップショット更新: `npx cdk synth --force`
+3. スタック定義を確認
+
+### ステップ4: 修正提案
+
+エラー内容に基づいて具体的な修正方法を提案します。
+
+**提案フォーマット**:
+```
+🔴 エラー検出: <エラー種別>
+
+ファイル: <ファイルパス>:<行番号>
+エラー内容: <エラーメッセージ>
+
+原因: <原因の説明>
+
+修正案:
+1. <修正手順1>
+2. <修正手順2>
+
+修正後の再実行コマンド:
+./scripts/pre-deploy-check.sh
+```
+
+### ステップ5: 修正実施
+
+ユーザーの承認後、修正を実施します。
+
+**修正パターン例**:
+
+#### パターン1: 未使用インポート削除
+```typescript
+// Before
+import React, { useState } from 'react';
+import { UnusedType } from './types';
+
+// After
+import { useState } from 'react';
+```
+
+#### パターン2: console.log削除
+```typescript
+// Before
+const result = await fetchData();
+console.log('Result:', result);
+return result;
+
+// After
+const result = await fetchData();
+return result;
+```
+
+#### パターン3: テスト修正
+```typescript
+// Before
+it('renders race information', () => {
+  render(<RaceCard />);
+});
+
+// After
+it('renders race information', () => {
+  const mockRace = { name: 'Test Race', venue: 'Tokyo' };
+  render(<RaceCard race={mockRace} />);
+});
+```
+
+### ステップ6: 再実行・検証
+
+修正後、再度チェックスクリプトを実行して全て通過することを確認します。
+
+**コマンド**:
+```bash
+./scripts/pre-deploy-check.sh
+```
+
+**成功出力**:
+```
+✅ バックエンドテスト成功
+✅ フロントエンドリント成功
+✅ フロントエンドテスト成功
+✅ CDK Synth成功
+
+🎉 全てのチェックに合格しました。デプロイ可能です。
+```
+
+### ステップ7: デプロイガイダンス
+
+全チェック通過後、デプロイ手順を案内します。
+
+**フロントエンドデプロイ**:
+```bash
+# Amplifyが自動デプロイ（mainブランチへのマージ後）
+git push origin main
+```
+
+**バックエンドデプロイ**:
+```bash
+cd cdk
+
+# 重要: --context jravan=true を必ず付ける
+npx cdk deploy --all --context jravan=true --require-approval never
+```
+
+**デプロイ後確認**:
+1. CloudWatch Logs でエラーがないか確認
+2. ブラウザで動作確認
+3. レース情報が正しく表示されるか確認
+
+## 出力形式
+
+### 全チェック成功時
+
+```
+✅ デプロイ前チェック完了
+
+実行内容:
+- [✅] バックエンドテスト (pytest)
+- [✅] フロントエンドリント (npm run lint)
+- [✅] フロントエンドテスト (npm run test:run)
+- [✅] CDK Synth (npx cdk synth)
+
+🎉 全てのチェックに合格しました。
+
+次のアクション:
+- [ ] フロントエンドデプロイ（git push origin main）
+- [ ] バックエンドデプロイ（cd cdk && npx cdk deploy --all --context jravan=true）
+- [ ] デプロイ後の動作確認
+```
+
+### エラー検出時
+
+```
+🔴 デプロイ前チェックでエラーを検出
+
+実行内容:
+- [✅] バックエンドテスト (pytest)
+- [🔴] フロントエンドリント (npm run lint) - 2件のエラー
+- [⏭️] フロントエンドテスト (スキップ)
+- [⏭️] CDK Synth (スキップ)
+
+---
+🔴 エラー #1: 未使用変数
+
+ファイル: frontend/src/pages/RaceDetailPage.tsx:15
+エラー: 'unused' is defined but never used
+
+原因: インポートしたが使用していない変数
+
+修正案:
+1. 該当インポートを削除
+2. または変数名の先頭に _ を付ける（意図的な未使用の場合）
+
+---
+🔴 エラー #2: console.log残存
+
+ファイル: frontend/src/api/client.ts:89
+エラー: Unexpected console statement
+
+原因: デバッグ用のconsole.logが残っている
+
+修正案:
+1. console.log を削除
+2. または logger.debug() に置き換え
+
+---
+
+次のアクション:
+- [ ] エラー修正
+- [ ] 再実行: ./scripts/pre-deploy-check.sh
+```
+
+## エラーハンドリング
+
+### 頻出エラーと対処法
+
+1. **pytest: ModuleNotFoundError**
+   ```
+   ModuleNotFoundError: No module named 'src'
+   ```
+   - 対処: `cd main/backend` で正しいディレクトリに移動
+
+2. **npm: command not found**
+   ```
+   bash: npm: command not found
+   ```
+   - 対処: Node.js がインストールされているか確認
+
+3. **CDK: AWS認証エラー**
+   ```
+   Error: Unable to resolve AWS credentials
+   ```
+   - 対処: `aws configure` で認証情報を設定
+
+4. **テストタイムアウト**
+   ```
+   FAILED tests/api/test_handler.py::test_timeout
+   ```
+   - 対処: モックの設定を確認、または `pytest -v --timeout=60`
+
+## 使用例
+
+### 例1: リントエラー修正
+
+```
+/deploy-prep
+
+実行中...
+
+🔴 デプロイ前チェックでエラーを検出
+
+- [✅] バックエンドテスト (pytest)
+- [🔴] フロントエンドリント (npm run lint) - 3件のエラー
+
+---
+エラー #1: 未使用インポート
+ファイル: frontend/src/pages/RaceDetailPage.tsx:5
+修正: `import { UnusedComponent } from './components'` を削除
+---
+
+修正しますか？
+> はい
+
+✅ 修正完了。再実行中...
+
+✅ 全てのチェックに合格しました。
+```
+
+### 例2: テスト失敗修正
+
+```
+/deploy-prep
+
+実行中...
+
+🔴 デプロイ前チェックでエラーを検出
+
+- [🔴] バックエンドテスト (pytest) - 1件の失敗
+
+---
+エラー: test_get_race_weights 失敗
+ファイル: tests/infrastructure/providers/test_mock_race_data_provider.py:45
+
+原因: Mock実装が最新のポート定義に追従していない
+
+修正案:
+1. MockRaceDataProvider に get_race_weights メソッドを追加
+2. テストケースのMockデータを更新
+
+修正しますか？
+> はい
+
+✅ 修正完了。再実行中...
+
+✅ 全てのチェックに合格しました。
+```
+
+## 参照スクリプト
+
+### pre-deploy-check.sh の内容
+
+スクリプトは以下のチェックを順次実行:
+
+```bash
+#!/bin/bash
+
+# 1. バックエンドテスト
+cd backend
+pytest
+
+# 2. フロントエンドリント
+cd ../frontend
+npm run lint
+
+# 3. フロントエンドテスト
+npm run test:run
+
+# 4. CDK Synth
+cd ../cdk
+npx cdk synth
+```
+
+## 注意事項
+
+- **実行環境**: 必ず `main` ディレクトリ内で実行
+- **CDK Context**: デプロイ時は `--context jravan=true` を必ず付与
+- **git worktree**: feature ブランチで作業、main への直接 push 禁止
+- **CI/CD**: GitHub Actions でも同じチェックが実行される
+- **テスト順序**: 1つでも失敗したら後続をスキップ（高速フィードバック）
+
+## デプロイ後の確認手順
+
+1. **CloudWatch Logs確認**
+   ```bash
+   aws logs tail /aws/lambda/baken-kaigi-races --follow
+   ```
+
+2. **API動作確認**
+   ```bash
+   curl -X GET "https://api.example.com/races?date=2026-01-23"
+   ```
+
+3. **ブラウザ確認**
+   - Amplify デプロイURL にアクセス
+   - レース一覧が正しく表示されるか
+   - エラートーストが出ないか

--- a/.claude/skills/ec2-sync/SKILL.md
+++ b/.claude/skills/ec2-sync/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: ec2-sync
+description: JRA-VANデータ同期・EC2操作簡素化（複雑なSSMコマンドをシンプルなインターフェースでラップ）
+version: 1.0.0
+tools:
+  - Bash
+  - Read
+skill_type: workflow
+auto_invoke: false
+---
+
+# EC2データ同期・操作簡素化
+
+## 概要
+
+JRA-VAN データ同期とEC2操作を簡単なコマンドで実行できるようにします。複雑なAWS SSMコマンドを簡潔なインターフェースでラップし、ミスを防止します。
+
+## 主要機能
+
+1. **ファイルアップロード**: Base64エンコード自動化
+2. **データ差分同期**: 最新データのみ取得
+3. **指定日からの完全同期**: 特定日以降のデータを再取得
+4. **ログ確認**: リアルタイムログ表示
+
+## 入力形式
+
+```
+/ec2-sync <操作>
+
+操作:
+  upload <ファイル名>       - ファイルをEC2に送信
+  sync                      - 差分同期実行
+  sync-from <YYYYMMDD>      - 指定日からの完全同期
+  logs                      - ログ確認
+  status                    - EC2インスタンス状態確認
+```
+
+## 実行プロセス
+
+### 操作1: ファイルアップロード
+
+**コマンド**:
+```
+/ec2-sync upload sync_jvlink.py
+```
+
+**実行内容**:
+1. EC2インスタンスIDを自動取得
+2. ファイルをBase64エンコード
+3. SSM経由でEC2に送信
+4. 送信完了を確認
+
+**内部コマンド**:
+```bash
+# インスタンスID取得
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*jravan*" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)
+
+# Base64エンコード＆送信
+FILE_B64=$(base64 jravan-api/sync_jvlink.py | tr -d '\n')
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\sync_jvlink.py -Encoding UTF8 -Force\"]"
+
+echo "✅ sync_jvlink.py を送信しました"
+```
+
+### 操作2: データ差分同期
+
+**コマンド**:
+```
+/ec2-sync sync
+```
+
+**実行内容**:
+1. EC2で `sync_jvlink.py` を実行
+2. 最新データのみ取得
+3. 進捗をログで確認
+
+**内部コマンド**:
+```bash
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*jravan*" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)
+
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py"]'
+
+echo "✅ データ差分同期を開始しました"
+echo "ログ確認: /ec2-sync logs"
+```
+
+### 操作3: 指定日からの完全同期
+
+**コマンド**:
+```
+/ec2-sync sync-from 20260101
+```
+
+**実行内容**:
+1. 2026年1月1日以降のデータを完全に再取得
+2. 既存データは上書き
+3. 大量データの場合は時間がかかる
+
+**内部コマンド**:
+```bash
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*jravan*" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)
+
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py --from 20260101"]'
+
+echo "✅ 2026/01/01 からの完全同期を開始しました"
+echo "⚠️  大量データのため、完了まで数時間かかる場合があります"
+echo "ログ確認: /ec2-sync logs"
+```
+
+### 操作4: ログ確認
+
+**コマンド**:
+```
+/ec2-sync logs
+```
+
+**実行内容**:
+1. CloudWatch Logs から最新ログを取得
+2. リアルタイムでログをフォロー
+
+**内部コマンド**:
+```bash
+aws logs tail /aws/ec2/jravan --follow
+```
+
+**出力例**:
+```
+2026-01-23 15:30:00 [INFO] 同期開始: 2026-01-20 から
+2026-01-23 15:30:05 [INFO] レースデータ取得中: 東京 1R
+2026-01-23 15:30:10 [INFO] レースデータ取得中: 東京 2R
+...
+2026-01-23 15:35:00 [INFO] 同期完了: 36レース
+```
+
+### 操作5: EC2インスタンス状態確認
+
+**コマンド**:
+```
+/ec2-sync status
+```
+
+**実行内容**:
+1. EC2インスタンスの状態を確認
+2. SSMエージェントの接続状態を確認
+
+**内部コマンド**:
+```bash
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*jravan*" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)
+
+# インスタンス状態
+aws ec2 describe-instances \
+  --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[].Instances[].[InstanceId,State.Name,LaunchTime]' \
+  --output table
+
+# SSM接続状態
+aws ssm describe-instance-information \
+  --filters "Key=InstanceIds,Values=$INSTANCE_ID" \
+  --query 'InstanceInformationList[].[InstanceId,PingStatus,LastPingDateTime]' \
+  --output table
+```
+
+**出力例**:
+```
+---------------------------------------------------------
+|                 DescribeInstances                     |
++------------------------+----------+--------------------+
+|  i-0123456789abcdef0  | running  | 2026-01-23T10:00:00|
++------------------------+----------+--------------------+
+
+---------------------------------------------------------
+|         DescribeInstanceInformation                    |
++------------------------+-----------+--------------------+
+|  i-0123456789abcdef0  | Online    | 2026-01-23T15:45:00|
++------------------------+-----------+--------------------+
+```
+
+## 出力形式
+
+### ファイルアップロード成功時
+
+```
+📤 ファイルアップロード
+
+ファイル: sync_jvlink.py
+送信先: EC2 (i-0123456789abcdef0)
+
+実行中...
+
+✅ 送信完了
+
+次のアクション:
+- [ ] データ同期: /ec2-sync sync
+```
+
+### データ同期開始時
+
+```
+🔄 データ差分同期
+
+インスタンス: i-0123456789abcdef0
+実行コマンド: python sync_jvlink.py
+
+✅ 同期を開始しました
+
+進捗確認:
+- /ec2-sync logs でリアルタイムログ表示
+```
+
+### 完全同期開始時
+
+```
+🔄 完全同期（2026/01/01 から）
+
+インスタンス: i-0123456789abcdef0
+実行コマンド: python sync_jvlink.py --from 20260101
+
+✅ 完全同期を開始しました
+
+⚠️  注意:
+- 大量データのため、完了まで数時間かかる場合があります
+- 既存データは上書きされます
+
+進捗確認:
+- /ec2-sync logs でリアルタイムログ表示
+```
+
+## よくある操作フロー
+
+### フロー1: スクリプト更新 → データ同期
+
+```
+1. /ec2-sync upload sync_jvlink.py
+   → スクリプトをEC2に送信
+
+2. /ec2-sync sync
+   → 差分同期実行
+
+3. /ec2-sync logs
+   → 進捗確認
+```
+
+### フロー2: 特定期間のデータ再取得
+
+```
+1. /ec2-sync sync-from 20260120
+   → 2026/01/20 以降のデータを完全同期
+
+2. /ec2-sync logs
+   → 進捗確認（数時間かかる可能性）
+```
+
+### フロー3: EC2状態確認
+
+```
+1. /ec2-sync status
+   → インスタンス状態とSSM接続確認
+
+2. エラーの場合はAWSコンソールで確認
+```
+
+## エラーハンドリング
+
+### よくあるエラー
+
+1. **インスタンスIDが見つからない**
+   ```
+   Error: No instances found with tag 'jravan'
+   ```
+   - 対処: EC2インスタンスが起動しているか確認
+   - コマンド: `aws ec2 describe-instances`
+
+2. **SSMエージェント未接続**
+   ```
+   Error: TargetNotConnected
+   ```
+   - 対処: SSMエージェントの起動を確認
+   - コマンド: `/ec2-sync status`
+
+3. **ファイルが見つからない**
+   ```
+   Error: File not found: jravan-api/sync_jvlink.py
+   ```
+   - 対処: カレントディレクトリを確認
+   - コマンド: `ls jravan-api/`
+
+4. **同期スクリプトエラー**
+   ```
+   Error in sync_jvlink.py
+   ```
+   - 対処: ログを確認してスクリプトを修正
+   - コマンド: `/ec2-sync logs`
+
+## セキュリティ
+
+- **認証**: AWS認証情報が必要（`aws configure`）
+- **IAM権限**: EC2, SSM, CloudWatch Logs の読み取り・書き込み権限
+- **データ保護**: スクリプト内に機密情報をハードコードしない
+
+## 対象ファイル
+
+### アップロード可能なファイル
+- `sync_jvlink.py` - データ同期スクリプト（メイン）
+- `race_api.py` - FastAPI サーバー
+- `config.py` - 設定ファイル
+- `requirements.txt` - Python依存関係
+
+### EC2配置先
+- `C:\jravan-api\<ファイル名>`
+
+## 使用例
+
+### 例1: スクリプト更新と同期
+
+```
+/ec2-sync upload sync_jvlink.py
+
+📤 ファイルアップロード
+ファイル: sync_jvlink.py
+✅ 送信完了
+
+/ec2-sync sync
+
+🔄 データ差分同期
+✅ 同期を開始しました
+
+/ec2-sync logs
+
+2026-01-23 15:30:00 [INFO] 同期開始
+2026-01-23 15:30:05 [INFO] レースデータ取得中: 東京 1R
+...
+2026-01-23 15:35:00 [INFO] 同期完了: 36レース
+```
+
+### 例2: 特定日からの再同期
+
+```
+/ec2-sync sync-from 20260115
+
+🔄 完全同期（2026/01/15 から）
+✅ 完全同期を開始しました
+
+⚠️  数時間かかる可能性があります
+
+/ec2-sync logs
+
+2026-01-23 16:00:00 [INFO] 完全同期開始: 2026-01-15 から
+2026-01-23 16:00:30 [INFO] 処理中: 2026-01-15 東京
+...
+```
+
+## 参照
+
+- **CLAUDE.md**: `main/CLAUDE.md` の「EC2 コード更新」セクション
+- **同期スクリプト**: `jravan-api/sync_jvlink.py`
+- **AWS SSM**: https://docs.aws.amazon.com/systems-manager/
+- **CloudWatch Logs**: https://docs.aws.amazon.com/cloudwatch/
+
+## 注意事項
+
+- **同期時間**: 大量データは数時間かかる
+- **データ上書き**: 完全同期は既存データを上書き
+- **SSM制限**: コマンド実行は最大30分でタイムアウト
+- **ログ保持**: CloudWatch Logs は7日間保持

--- a/.claude/skills/issue-to-task/SKILL.md
+++ b/.claude/skills/issue-to-task/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: issue-to-task
+description: GitHub Issue→実装タスク生成（Issue分析→タスク分解→チェックリスト作成）
+version: 1.0.0
+tools:
+  - Bash
+  - Read
+  - Grep
+skill_type: workflow
+auto_invoke: false
+---
+
+# Issue→実装タスク生成
+
+## 概要
+
+GitHub Issueの内容から実装タスクリストとチェックリストを自動生成します。Issue分析→タスク分解の時間短縮と実装漏れ防止を目的とします。
+
+## 入力形式
+
+スキル呼び出し時にIssue番号を指定:
+
+```
+/issue-to-task <Issue番号>
+```
+
+または
+
+```
+/issue-to-task
+
+Issue: #<番号>
+```
+
+## 実行プロセス
+
+### ステップ1: Issue情報取得
+
+**コマンド**:
+```bash
+gh issue view <Issue番号> --json title,body,labels,assignees
+```
+
+**取得情報**:
+- タイトル
+- 本文
+- ラベル
+- アサイニー
+
+**出力例**:
+```json
+{
+  "title": "日付セレクターを動的な開催日一覧に変更",
+  "body": "現状の日付選択UIを、実際に開催があった日付のみを表示する形式に変更する。\n\n## 背景\n...",
+  "labels": ["enhancement", "frontend"],
+  "assignees": []
+}
+```
+
+### ステップ2: Issue分析
+
+#### 分類
+
+**Issue種別判定**:
+1. **Feature（新機能）**: `feat:` で始まる、`enhancement` ラベル
+2. **Bug（バグ修正）**: `fix:` で始まる、`bug` ラベル
+3. **Refactor（リファクタリング）**: `refactor:` で始まる
+4. **Docs（ドキュメント）**: `docs:` で始まる
+5. **Test（テスト追加）**: `test:` で始まる
+
+#### 影響範囲の特定
+
+**ラベルから判定**:
+- `frontend` → フロントエンド実装が必要
+- `backend` → バックエンド実装が必要
+- `api` → API拡張が必要
+- `infra` → インフラ変更が必要
+- `database` → DB変更が必要
+
+### ステップ3: タスク分解
+
+#### タスク抽出パターン
+
+**Feature（新機能）の場合**:
+1. **設計**
+   - データモデル設計（必要に応じて）
+   - UI/UX設計（フロントエンド）
+   - API設計（バックエンド）
+
+2. **実装**
+   - バックエンド実装
+     - ports定義
+     - provider実装
+     - handler実装
+     - テスト作成
+   - フロントエンド実装
+     - 型定義
+     - APIクライアント
+     - UIコンポーネント
+     - ページ実装
+
+3. **検証**
+   - ローカルテスト
+   - デプロイ前チェック
+   - 動作確認
+
+4. **ドキュメント**
+   - README更新（必要に応じて）
+   - CLAUDE.md更新（必要に応じて）
+
+**Bug（バグ修正）の場合**:
+1. **原因調査**
+   - エラーログ確認
+   - 再現手順確認
+   - コードレビュー
+
+2. **修正実装**
+   - バグ修正
+   - テスト追加（再発防止）
+
+3. **検証**
+   - 修正確認
+   - 回帰テスト
+
+### ステップ4: ファイル特定
+
+**影響を受けるファイル一覧**:
+
+**バックエンド**:
+```
+- backend/src/domain/ports/<port_name>.py
+- backend/src/infrastructure/providers/<provider_name>.py
+- backend/src/api/handlers/<handler_name>.py
+- backend/tests/**/<test_file>.py
+```
+
+**フロントエンド**:
+```
+- frontend/src/types/index.ts
+- frontend/src/api/client.ts
+- frontend/src/pages/<Page>.tsx
+- frontend/src/components/<Component>.tsx
+```
+
+**インフラ**:
+```
+- cdk/lib/stacks/<stack_name>.ts
+```
+
+### ステップ5: テスト項目の抽出
+
+**テストカテゴリー**:
+1. **単体テスト**: 関数・メソッドレベル
+2. **統合テスト**: API・コンポーネントレベル
+3. **E2Eテスト**: ユーザーシナリオレベル（手動）
+
+**テスト項目例**:
+```
+- [ ] バックエンド: 開催日一覧取得APIが正しくデータを返す
+- [ ] バックエンド: 存在しない日付範囲でエラーハンドリング
+- [ ] フロントエンド: 開催日一覧が正しく表示される
+- [ ] フロントエンド: 日付選択時にレース一覧が更新される
+- [ ] E2E: ブラウザで日付選択→レース表示の流れを確認
+```
+
+## 出力形式
+
+```
+📋 実装タスク生成完了
+
+Issue: #<番号> - <タイトル>
+種別: <Feature/Bug/Refactor/etc>
+影響範囲: <Frontend/Backend/API/etc>
+
+## タスクリスト
+
+### 1. 設計
+- [ ] データモデル設計（開催日一覧のAPI仕様）
+- [ ] UI設計（日付セレクターのデザイン）
+
+### 2. バックエンド実装
+- [ ] ports定義: get_race_dates メソッドを追加
+- [ ] JRA-VAN Provider実装: get_race_dates を実装
+- [ ] Mock Provider実装: get_race_dates のMock実装
+- [ ] Handler実装: GET /races/dates エンドポイント作成
+- [ ] テスト作成: test_get_race_dates.py
+
+### 3. フロントエンド実装
+- [ ] 型定義: ApiRaceDatesResponse 型を追加
+- [ ] APIクライアント: getRaceDates メソッドを追加
+- [ ] コンポーネント: DateSelector コンポーネント作成
+- [ ] ページ更新: RacesPage に DateSelector を統合
+
+### 4. 検証
+- [ ] pytest 実行（バックエンド）
+- [ ] npm run test 実行（フロントエンド）
+- [ ] デプロイ前チェック実行
+- [ ] ローカル動作確認
+
+### 5. デプロイ
+- [ ] PRレビュー対応
+- [ ] mainブランチにマージ
+- [ ] CDKデプロイ（--context jravan=true）
+- [ ] 本番環境で動作確認
+
+## 影響ファイル
+
+**バックエンド**:
+- `backend/src/domain/ports/race_data_provider.py`
+- `backend/src/infrastructure/providers/jravan_race_data_provider.py`
+- `backend/src/infrastructure/providers/mock_race_data_provider.py`
+- `backend/src/api/handlers/races.py`
+- `backend/tests/application/use_cases/test_get_race_dates.py`
+
+**フロントエンド**:
+- `frontend/src/types/index.ts`
+- `frontend/src/api/client.ts`
+- `frontend/src/components/DateSelector.tsx` (新規)
+- `frontend/src/pages/RacesPage.tsx`
+
+## テスト項目
+
+**バックエンド**:
+- [ ] 開催日一覧取得APIが日付範囲を正しく返す
+- [ ] from_date, to_date パラメータが機能する
+- [ ] データがない場合は空配列を返す
+- [ ] 日付が昇順でソートされている
+
+**フロントエンド**:
+- [ ] 開催日一覧が正しく表示される
+- [ ] 日付選択時にレース一覧APIが呼ばれる
+- [ ] ローディング状態が正しく表示される
+- [ ] エラー時にトースト通知が表示される
+
+**E2E（手動）**:
+- [ ] ブラウザで日付セレクターが表示される
+- [ ] 開催日のみが選択可能
+- [ ] 日付選択するとレース一覧が更新される
+- [ ] モバイル画面でも正しく動作する
+
+## 推奨実装順序
+
+1. バックエンドAPI実装（TDD）
+2. フロントエンド型定義・APIクライアント
+3. フロントエンドUIコンポーネント
+4. 統合テスト
+5. デプロイ
+
+## 推定工数
+
+- バックエンド実装: 2時間
+- フロントエンド実装: 3時間
+- テスト・検証: 1時間
+- 合計: 約6時間
+```
+
+## 使用例
+
+### 例1: 新機能追加Issue
+
+```
+/issue-to-task 39
+
+Issue取得中...
+
+📋 実装タスク生成完了
+
+Issue: #39 - 日付セレクターを動的な開催日一覧に変更
+種別: Feature (enhancement)
+影響範囲: Frontend, Backend, API
+
+## タスクリスト
+（上記の形式で出力）
+
+次のアクション:
+- [ ] git worktree add で作業ブランチ作成
+- [ ] /api-extend スキルでバックエンド実装
+- [ ] /ui-component スキルでフロントエンド実装
+```
+
+### 例2: バグ修正Issue
+
+```
+/issue-to-task 42
+
+Issue取得中...
+
+📋 実装タスク生成完了
+
+Issue: #42 - レース詳細でオッズが正しく表示されない
+種別: Bug (bug)
+影響範囲: Frontend
+
+## タスクリスト
+
+### 1. 原因調査
+- [ ] エラーログ確認
+- [ ] オッズデータの型を確認
+- [ ] マッピング関数を確認
+
+### 2. 修正実装
+- [ ] mapApiRunnerToRunner 関数を修正
+- [ ] オッズのパース処理を追加
+- [ ] テスト追加（再発防止）
+
+### 3. 検証
+- [ ] ユニットテスト実行
+- [ ] ブラウザで動作確認
+
+影響ファイル:
+- `frontend/src/types/index.ts`
+- `frontend/src/types/index.test.ts` (新規)
+
+推定工数: 1時間
+```
+
+## 参照コマンド
+
+```bash
+# Issue一覧表示
+gh issue list
+
+# Issue詳細表示
+gh issue view <Issue番号>
+
+# Issueコメント表示
+gh issue view <Issue番号> --comments
+
+# Issue作成
+gh issue create --title "タイトル" --body "本文"
+```
+
+## 注意事項
+
+- **Issue内容の明確性**: 曖昧なIssueは詳細化を依頼
+- **スコープの適切性**: 大きすぎるIssueは分割提案
+- **既存実装の確認**: 類似機能の実装パターンを参照
+- **テストの重要性**: テスト項目は必ず含める

--- a/.claude/skills/jravan-ec2/SKILL.md
+++ b/.claude/skills/jravan-ec2/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: jravan-ec2
+description: JRA-VAN API（EC2）へのファイル送信とコード更新ガイド
+version: 1.0.0
+tools:
+  - Bash
+  - Read
+skill_type: knowledge
+auto_invoke: false
+---
+
+# JRA-VAN EC2コード更新ガイド
+
+## 概要
+
+JRA-VAN API（EC2 Windows Server）にコードを送信し、更新する際の定型コマンドを提供します。EC2にはGitがインストールされていないため、AWS SSM経由で直接ファイルを送信します。
+
+## 背景
+
+- **環境**: EC2 Windows Server
+- **制約**: Gitがインストールされていない
+- **転送方法**: AWS SSM + Base64エンコード
+- **対象ファイル**: `jravan-api/*.py`
+
+## 実行プロセス
+
+### ステップ1: EC2インスタンスID確認
+
+**コマンド**:
+```bash
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=*jravan*" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output text)
+
+echo "Instance ID: $INSTANCE_ID"
+```
+
+**出力例**:
+```
+Instance ID: i-0123456789abcdef0
+```
+
+### ステップ2: ファイルをBase64エンコードして送信
+
+**コマンドテンプレート**:
+```bash
+# 1. ファイルをBase64エンコード
+FILE_B64=$(base64 jravan-api/<ファイル名>.py | tr -d '\n')
+
+# 2. SSM経由でEC2に送信
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\<ファイル名>.py -Encoding UTF8 -Force\"]"
+```
+
+**実行例（sync_jvlink.py を送信）**:
+```bash
+FILE_B64=$(base64 jravan-api/sync_jvlink.py | tr -d '\n')
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\sync_jvlink.py -Encoding UTF8 -Force\"]"
+```
+
+### ステップ3: データ再同期
+
+#### 差分同期（デフォルト）
+
+**コマンド**:
+```bash
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py"]'
+```
+
+#### 指定日からの完全同期
+
+**コマンド**:
+```bash
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py --from 20260101"]'
+```
+
+**引数**:
+- `--from YYYYMMDD`: 指定日付からデータを同期
+
+### ステップ4: ログ確認
+
+**コマンド**:
+```bash
+# CloudWatch Logsでログを確認
+aws logs tail /aws/ec2/jravan --follow
+```
+
+## ワンライナーコマンド集
+
+### ファイル送信ワンライナー
+
+```bash
+# sync_jvlink.py を送信
+INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=*jravan*" --query 'Reservations[].Instances[].InstanceId' --output text) && \
+FILE_B64=$(base64 jravan-api/sync_jvlink.py | tr -d '\n') && \
+aws ssm send-command --instance-ids "$INSTANCE_ID" --document-name "AWS-RunPowerShellScript" --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\sync_jvlink.py -Encoding UTF8 -Force\"]"
+```
+
+### 複数ファイル一括送信
+
+```bash
+# 複数ファイルをループで送信
+for file in sync_jvlink.py race_api.py; do
+  FILE_B64=$(base64 jravan-api/$file | tr -d '\n')
+  aws ssm send-command \
+    --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunPowerShellScript" \
+    --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\$file -Encoding UTF8 -Force\"]"
+  echo "Sent: $file"
+  sleep 2
+done
+```
+
+### 送信 → 同期 → ログ確認（一連の流れ）
+
+```bash
+# 1. ファイル送信
+INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=*jravan*" --query 'Reservations[].Instances[].InstanceId' --output text)
+FILE_B64=$(base64 jravan-api/sync_jvlink.py | tr -d '\n')
+aws ssm send-command --instance-ids "$INSTANCE_ID" --document-name "AWS-RunPowerShellScript" --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\sync_jvlink.py -Encoding UTF8 -Force\"]"
+
+# 2. 5秒待機
+sleep 5
+
+# 3. データ再同期
+aws ssm send-command --instance-ids "$INSTANCE_ID" --document-name "AWS-RunPowerShellScript" --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py"]'
+
+# 4. ログ確認
+aws logs tail /aws/ec2/jravan --follow
+```
+
+## エラーハンドリング
+
+### よくあるエラー
+
+1. **インスタンスIDが見つからない**
+   ```
+   Error: An error occurred (InvalidInstanceID.NotFound)
+   ```
+   - 対処: EC2インスタンスが起動しているか確認
+   - コマンド: `aws ec2 describe-instances --filters "Name=tag:Name,Values=*jravan*"`
+
+2. **SSMエージェント未起動**
+   ```
+   Error: TargetNotConnected
+   ```
+   - 対処: EC2でSSMエージェントが起動しているか確認
+   - 確認方法: AWSコンソール > Systems Manager > Fleet Manager
+
+3. **PowerShell構文エラー**
+   ```
+   Error: At line:1 char:...
+   ```
+   - 対処: PowerShellコマンドのエスケープを確認
+   - Base64エンコードの改行削除 `tr -d '\n'` を確認
+
+4. **ファイルが見つからない**
+   ```
+   base64: jravan-api/sync_jvlink.py: No such file or directory
+   ```
+   - 対処: カレントディレクトリを確認、`ls jravan-api/` で存在確認
+
+## セキュリティ上の注意
+
+- **認証情報**: スクリプトに認証情報をハードコードしない
+- **環境変数**: 機密情報は環境変数で管理
+- **IAM権限**: 最小権限の原則（EC2, SSM のみ）
+
+## 対象ファイル
+
+### 主要ファイル
+- `sync_jvlink.py` - JV-Linkデータ同期スクリプト
+- `race_api.py` - レースAPIサーバー（FastAPI）
+- `config.py` - 設定ファイル
+
+## 使用例
+
+### 例1: sync_jvlink.py を更新して差分同期
+
+```
+/jravan-ec2
+
+ファイル: sync_jvlink.py
+同期モード: 差分
+
+実行コマンド:
+
+# 1. インスタンスID取得
+INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=*jravan*" --query 'Reservations[].Instances[].InstanceId' --output text)
+
+# 2. ファイル送信
+FILE_B64=$(base64 jravan-api/sync_jvlink.py | tr -d '\n')
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters "commands=[\"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('$FILE_B64')) | Out-File -FilePath C:\\jravan-api\\sync_jvlink.py -Encoding UTF8 -Force\"]"
+
+# 3. 差分同期実行
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py"]'
+
+完了。ログを確認してください。
+```
+
+### 例2: 特定日からの完全同期
+
+```
+/jravan-ec2
+
+同期モード: 2026年1月1日から完全同期
+
+実行コマンド:
+
+aws ssm send-command \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name "AWS-RunPowerShellScript" \
+  --parameters 'commands=["cd C:\\jravan-api; python sync_jvlink.py --from 20260101"]'
+```
+
+## 関連ドキュメント
+
+- **AWS SSM**: https://docs.aws.amazon.com/systems-manager/
+- **CLAUDE.md**: `main/CLAUDE.md` の「EC2 コード更新」セクション
+- **JV-Link仕様**: `main/aidlc-docs/construction/unit_01_ai_dialog_public/docs/jra-van_setup.md`
+
+## 注意事項
+
+- **Windows Server**: PowerShellコマンドを使用
+- **Base64エンコード**: 改行を必ず削除（`tr -d '\n'`）
+- **タイムアウト**: SSMコマンドは最大30分でタイムアウト
+- **同期時間**: 大量データ同期は時間がかかる（数時間）

--- a/.claude/skills/ui-component/SKILL.md
+++ b/.claude/skills/ui-component/SKILL.md
@@ -1,0 +1,453 @@
+---
+name: ui-component
+description: ReactコンポーネントとTailwind CSSスタイリングの実装パターン提供
+version: 1.0.0
+tools:
+  - Read
+  - Grep
+  - Glob
+skill_type: knowledge
+auto_invoke: false
+---
+
+# フロントエンドUI実装パターン
+
+## 概要
+
+Reactコンポーネントの作成とTailwind CSSスタイリングの定型パターンを提供します。UI実装の標準化とデザインシステムの一貫性を確保します。
+
+## 技術スタック
+
+- **フレームワーク**: React 18 + TypeScript
+- **スタイリング**: Tailwind CSS 3
+- **状態管理**: Zustand
+- **ルーティング**: React Router v6
+- **ビルドツール**: Vite
+
+## コンポーネント実装パターン
+
+### 基本構造
+
+**ファイル構成**:
+```
+main/frontend/src/
+├── pages/          # ページコンポーネント
+│   └── RaceDetailPage.tsx
+├── components/     # 共通コンポーネント
+│   └── RaceCard.tsx
+├── stores/         # Zustand ストア
+│   ├── appStore.ts
+│   └── cartStore.ts
+├── types/          # 型定義
+│   └── index.ts
+└── api/            # APIクライアント
+    └── client.ts
+```
+
+### ページコンポーネントパターン
+
+**テンプレート**:
+```typescript
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAppStore } from '../stores/appStore';
+import type { <Type> } from '../types';
+import { apiClient } from '../api/client';
+
+export function <Page>Page() {
+  const { <param> } = useParams<{ <param>: string }>();
+  const navigate = useNavigate();
+  const showToast = useAppStore((state) => state.showToast);
+
+  const [data, setData] = useState<<Type> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!<param>) return;
+
+    let isMounted = true;
+
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+
+      const response = await apiClient.get<Resource>(<param>);
+
+      if (!isMounted) return;
+
+      if (response.success && response.data) {
+        setData(response.data);
+      } else {
+        setError(response.error || 'データ取得に失敗しました');
+      }
+
+      setLoading(false);
+    };
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [<param>]);
+
+  if (loading) return <LoadingSpinner />;
+  if (error) return <ErrorMessage message={error} />;
+  if (!data) return <EmptyState />;
+
+  return (
+    <div className="container mx-auto p-4">
+      {/* コンテンツ */}
+    </div>
+  );
+}
+```
+
+**重要な原則**:
+- `isMounted` フラグでメモリリーク防止
+- ローディング・エラー・空状態を適切にハンドリング
+- Zustand ストアでグローバル状態管理
+
+### 馬券関連UIパターン
+
+#### レースカード
+
+```typescript
+interface RaceCardProps {
+  race: Race;
+  onClick?: () => void;
+}
+
+export function RaceCard({ race, onClick }: RaceCardProps) {
+  return (
+    <div
+      className="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow cursor-pointer"
+      onClick={onClick}
+    >
+      {/* レース番号・時刻 */}
+      <div className="flex justify-between items-center mb-2">
+        <span className="text-sm font-bold text-gray-700">{race.number}</span>
+        <span className="text-sm text-gray-500">{race.time}</span>
+      </div>
+
+      {/* レース名 */}
+      <h3 className="text-lg font-bold mb-2">{race.name}</h3>
+
+      {/* 距離・馬場状態 */}
+      <div className="flex gap-2 flex-wrap">
+        {race.distance && (
+          <span className="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded">
+            {race.distance}m
+          </span>
+        )}
+        <span className="px-2 py-1 bg-green-100 text-green-800 text-xs rounded">
+          {race.condition}
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+#### 出走馬カード
+
+```typescript
+interface RunnerCardProps {
+  runner: Horse;
+  selected?: boolean;
+  onToggle?: () => void;
+}
+
+export function RunnerCard({ runner, selected, onToggle }: RunnerCardProps) {
+  return (
+    <div
+      className={`
+        border-2 rounded-lg p-3 cursor-pointer transition-all
+        ${selected ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-gray-400'}
+      `}
+      onClick={onToggle}
+    >
+      {/* 枠番・馬番 */}
+      <div className="flex items-center gap-2 mb-2">
+        <span
+          className="w-8 h-8 flex items-center justify-center rounded font-bold text-sm"
+          style={{
+            backgroundColor: runner.color,
+            color: runner.textColor,
+          }}
+        >
+          {runner.wakuBan}
+        </span>
+        <span className="text-lg font-bold">{runner.number}</span>
+      </div>
+
+      {/* 馬名 */}
+      <h4 className="font-semibold mb-1">{runner.name}</h4>
+
+      {/* 騎手 */}
+      <p className="text-sm text-gray-600 mb-2">{runner.jockey}</p>
+
+      {/* オッズ・人気 */}
+      <div className="flex justify-between items-center">
+        <span className="text-sm font-semibold text-orange-600">
+          {runner.odds.toFixed(1)}倍
+        </span>
+        <span className="text-xs text-gray-500">{runner.popularity}人気</span>
+      </div>
+
+      {/* 馬体重（オプション） */}
+      {runner.weight && (
+        <div className="mt-2 text-xs text-gray-600">
+          馬体重: {runner.weight}kg
+          {runner.weightDiff !== undefined && (
+            <span className={runner.weightDiff >= 0 ? 'text-red-600' : 'text-blue-600'}>
+              {' '}({runner.weightDiff >= 0 ? '+' : ''}{runner.weightDiff})
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### Tailwind CSSパターン
+
+#### 色の使い方
+
+**JRA公式カラー**:
+```typescript
+// 枠色（main/frontend/src/types/index.ts で定義）
+export const WakuColors: Record<number, { background: string; text: string }> = {
+  1: { background: '#FFFFFF', text: '#000000' }, // 白枠
+  2: { background: '#000000', text: '#FFFFFF' }, // 黒枠
+  3: { background: '#E8384F', text: '#FFFFFF' }, // 赤枠
+  4: { background: '#1E90FF', text: '#FFFFFF' }, // 青枠
+  5: { background: '#FFD700', text: '#000000' }, // 黄枠
+  6: { background: '#2E8B57', text: '#FFFFFF' }, // 緑枠
+  7: { background: '#FF8C00', text: '#FFFFFF' }, // 橙枠
+  8: { background: '#FF69B4', text: '#FFFFFF' }, // 桃枠
+};
+```
+
+**状態色**:
+```css
+/* 成功 */
+.bg-green-100 .text-green-800
+
+/* 警告 */
+.bg-yellow-100 .text-yellow-800
+
+/* エラー */
+.bg-red-100 .text-red-800
+
+/* 情報 */
+.bg-blue-100 .text-blue-800
+
+/* ニュートラル */
+.bg-gray-100 .text-gray-800
+```
+
+#### レイアウトパターン
+
+**コンテナ**:
+```tsx
+<div className="container mx-auto p-4 max-w-7xl">
+  {/* コンテンツ */}
+</div>
+```
+
+**カード**:
+```tsx
+<div className="bg-white rounded-lg shadow-md p-4">
+  {/* カードコンテンツ */}
+</div>
+```
+
+**グリッド（レスポンシブ）**:
+```tsx
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+  {/* グリッドアイテム */}
+</div>
+```
+
+**Flexbox**:
+```tsx
+{/* 横並び（両端揃え） */}
+<div className="flex justify-between items-center">
+  <span>左</span>
+  <span>右</span>
+</div>
+
+{/* 横並び（中央揃え） */}
+<div className="flex justify-center items-center gap-2">
+  <span>アイテム1</span>
+  <span>アイテム2</span>
+</div>
+```
+
+#### バッジパターン
+
+**グレード・クラスバッジ**:
+```tsx
+function getGradeBadgeColor(grade: RaceGrade): string {
+  switch (grade) {
+    case 'G1': return 'bg-gradient-to-r from-yellow-400 to-yellow-600 text-white';
+    case 'G2': return 'bg-gradient-to-r from-gray-300 to-gray-400 text-gray-800';
+    case 'G3': return 'bg-gradient-to-r from-orange-300 to-orange-500 text-white';
+    case 'L': return 'bg-black text-white';
+    case 'OP': return 'bg-gray-700 text-white';
+    default: return 'bg-gray-200 text-gray-700';
+  }
+}
+
+<span className={`px-2 py-1 text-xs font-bold rounded ${getGradeBadgeColor(race.gradeClass)}`}>
+  {race.gradeClass}
+</span>
+```
+
+**コース種別バッジ**:
+```tsx
+<span className={`px-2 py-1 text-xs rounded ${
+  race.trackType === '芝' ? 'bg-green-100 text-green-800' :
+  race.trackType === 'ダ' ? 'bg-amber-100 text-amber-800' :
+  'bg-gray-100 text-gray-800'
+}`}>
+  {race.trackType}
+</span>
+```
+
+### 状態管理パターン（Zustand）
+
+**ストア定義**:
+```typescript
+import { create } from 'zustand';
+
+interface AppState {
+  isLoading: boolean;
+  toastMessage: string | null;
+  setLoading: (loading: boolean) => void;
+  showToast: (message: string) => void;
+  hideToast: () => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  isLoading: false,
+  toastMessage: null,
+  setLoading: (loading) => set({ isLoading: loading }),
+  showToast: (message) => set({ toastMessage: message }),
+  hideToast: () => set({ toastMessage: null }),
+}));
+```
+
+**使用例**:
+```typescript
+// コンポーネント内
+const showToast = useAppStore((state) => state.showToast);
+const toastMessage = useAppStore((state) => state.toastMessage);
+
+// トースト表示
+showToast('カートに追加しました');
+```
+
+### フォーム入力パターン
+
+**数値入力（金額）**:
+```tsx
+<div className="mb-4">
+  <label className="block text-sm font-medium text-gray-700 mb-2">
+    掛け金
+  </label>
+  <div className="flex items-center gap-2">
+    <input
+      type="number"
+      min="100"
+      step="100"
+      value={betAmount}
+      onChange={(e) => setBetAmount(Number(e.target.value))}
+      className="border border-gray-300 rounded px-3 py-2 w-32"
+    />
+    <span className="text-gray-600">円</span>
+  </div>
+</div>
+```
+
+**セレクトボックス（券種）**:
+```tsx
+<select
+  value={betType}
+  onChange={(e) => setBetType(e.target.value as BetType)}
+  className="border border-gray-300 rounded px-3 py-2"
+>
+  {betTypes.map((type) => (
+    <option key={type} value={type}>
+      {BetTypeLabels[type]}
+    </option>
+  ))}
+</select>
+```
+
+### ボタンパターン
+
+**プライマリボタン**:
+```tsx
+<button
+  onClick={handleSubmit}
+  disabled={!isValid}
+  className="
+    bg-blue-600 hover:bg-blue-700
+    disabled:bg-gray-300 disabled:cursor-not-allowed
+    text-white font-semibold
+    px-6 py-3 rounded-lg
+    transition-colors
+  "
+>
+  カートに追加
+</button>
+```
+
+**セカンダリボタン**:
+```tsx
+<button
+  onClick={handleCancel}
+  className="
+    bg-white border border-gray-300
+    hover:bg-gray-50
+    text-gray-700
+    px-6 py-3 rounded-lg
+    transition-colors
+  "
+>
+  キャンセル
+</button>
+```
+
+**危険なアクション**:
+```tsx
+<button
+  onClick={handleDelete}
+  className="
+    bg-red-600 hover:bg-red-700
+    text-white font-semibold
+    px-4 py-2 rounded
+    transition-colors
+  "
+>
+  削除
+</button>
+```
+
+## 参照ファイル
+
+- **ページ例**: `main/frontend/src/pages/RaceDetailPage.tsx`
+- **型定義**: `main/frontend/src/types/index.ts`
+- **ストア**: `main/frontend/src/stores/`
+- **Tailwind設定**: `main/frontend/tailwind.config.js`
+
+## 注意事項
+
+- **レスポンシブ**: モバイルファーストで実装
+- **アクセシビリティ**: セマンティックHTMLを使用
+- **パフォーマンス**: useMemo, useCallback で最適化
+- **一貫性**: 既存コンポーネントのスタイルを踏襲

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ uv.lock
 /fix-*/
 /docs-*/
 /chore-*/
+
+# Claude Code個人設定
+.claude/settings.local.json


### PR DESCRIPTION
## 概要

開発効率化を目的として、10個のカスタムスキル/エージェントファイルを追加します。

## 追加内容

### Phase 1（即効性高）
- `/api-extend` - API拡張ワークフロー自動化（40分→10分、75%削減）
- `/copilot-review` - PRレビュー対応自動化（15分→3分、80%削減）
- `/deploy-prep` - デプロイ前チェック自動化

### Phase 2（品質向上）
- `tdd-generator` - TDD自動実行エージェント
- `/ddd-check` - DDD設計原則チェッカー

### Phase 3（効率化）
- `frontend-mapper` - API-フロント型マッピング自動生成
- `/jravan-ec2` - EC2コード更新ガイド

### 追加要望対応
- `/ui-component` - フロントエンドUI実装パターン（30分→15分、50%削減）
- `/issue-to-task` - Issue→実装タスク自動生成
- `/ec2-sync` - データ同期・EC2操作簡素化

## 影響範囲

- 新規追加: `.claude/agents/`, `.claude/skills/`
- 更新: `.gitignore`（settings.local.json を除外）

## テスト計画

- [ ] `/api-extend` で新しいAPIフィールド追加を試行
- [ ] `/deploy-prep` でデプロイ前チェック実行
- [ ] 各スキル/エージェントのドキュメント確認

## 期待される効果

| 指標 | 現状 | 目標 | 削減率 |
|------|------|------|--------|
| API拡張時間 | 40分 | 10分 | 75% |
| PRレビュー対応 | 15分 | 3分 | 80% |
| Mock更新漏れ | 3回/タスク | 0回 | 100% |
| デプロイ失敗 | 1回/5デプロイ | 0回 | 100% |
| UI実装時間 | 30分 | 15分 | 50% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)