### PR TITLE
fix: レース詳細・カート画面で会場コードを会場名に変更

### DIFF
--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useCartStore } from '../stores/cartStore';
-import { BetTypeLabels } from '../types';
+import { BetTypeLabels, getVenueName } from '../types';
 
 export function CartPage() {
   const navigate = useNavigate();
@@ -47,7 +47,7 @@ export function CartPage() {
               <div key={item.id} className="cart-item">
                 <div className="cart-item-info">
                   <div className="cart-item-race">
-                    {item.raceVenue} {item.raceNumber} {item.raceName}
+                    {getVenueName(item.raceVenue)} {item.raceNumber} {item.raceName}
                   </div>
                   <div className="cart-item-bet">
                     <span className="cart-item-bet-type">{BetTypeLabels[item.betType]}</span>

--- a/frontend/src/pages/RaceDetailPage.tsx
+++ b/frontend/src/pages/RaceDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAppStore } from '../stores/appStore';
 import { useCartStore } from '../stores/cartStore';
 import type { RaceDetail, BetType, BetMethod, ColumnSelections } from '../types';
-import { BetTypeLabels, BetTypeRequiredHorses, BetTypeOrdered } from '../types';
+import { BetTypeLabels, BetTypeRequiredHorses, BetTypeOrdered, getVenueName } from '../types';
 import { apiClient } from '../api/client';
 import { buildJraShutsubaUrl } from '../utils/jraUrl';
 import { getBetMethodLabel } from '../utils/betMethods';
@@ -235,7 +235,7 @@ export function RaceDetailPage() {
 
       <div className="race-detail-header">
         <div className="race-header-top">
-          <span className="race-number">{race.venue} {race.number}</span>
+          <span className="race-number">{getVenueName(race.venue)} {race.number}</span>
           {(() => {
             const jraUrl = buildJraShutsubaUrl(race);
             return jraUrl && (


### PR DESCRIPTION
## Summary
- レース詳細画面で会場コード（例: 06）を会場名（例: 中山）に変更
- カート画面でも同様に会場名を表示

## 変更内容
- `RaceDetailPage.tsx`: `getVenueName()` を使用
- `CartPage.tsx`: `getVenueName()` を使用

## Before / After
| 画面 | Before | After |
|------|--------|-------|
| レース詳細 | `06 1R` | `中山 1R` |
| カート | `06 1R 〇〇賞` | `中山 1R 〇〇賞` |

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)