### PR TITLE
feat: AIモデルをClaude Haiku 4.5に変更（コスト削減・高速化）

### DIFF
--- a/backend/src/infrastructure/clients/claude_ai_client.py
+++ b/backend/src/infrastructure/clients/claude_ai_client.py
@@ -24,7 +24,7 @@ class ClaudeAIClient(AIClient):
         if not api_key:
             raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
         self._client = anthropic.Anthropic(api_key=api_key)
-        self._model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+        self._model = os.environ.get("ANTHROPIC_MODEL", "claude-haiku-4-5-20250514")
 
     def generate_bet_feedback(self, context: BetFeedbackContext) -> str:
         """買い目データに基づくフィードバック文を生成する."""


### PR DESCRIPTION
## Summary

- デフォルトAIモデルを `claude-sonnet-4-20250514` から `claude-haiku-4-5-20250514` に変更
- **コスト67%削減**（入力 $3→$1、出力 $15→$5 per M tokens）
- **速度4-5倍向上**
- 精度は同等（SWE-bench 73.3%でSonnet 4と同レベル）

## Test plan

- [ ] CIテスト通過確認
- [ ] CDKデプロイ後、AI相談機能の動作確認

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)