### PR TITLE
feat: mainブランチマージ時のCDK・AgentCore自動デプロイ実装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:  # 他のワークフローから呼び出し可能
 
 jobs:
   frontend-test:
@@ -86,7 +87,7 @@ jobs:
 
       - name: Install CDK dependencies
         run: |
-          npm install -g aws-cdk
+          npm install -g aws-cdk@2
           pip install -r requirements.txt
           pip install pytest
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,104 +10,21 @@ permissions:
   contents: read
 
 jobs:
-  # CIジョブを先に実行
-  frontend-test:
-    name: Frontend Tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
+  # CIジョブを再利用
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
 
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run linter
-        run: npm run lint
-
-      - name: Run type check
-        run: npm run build
-
-      - name: Run tests
-        run: npm run test:run
-
-  backend-test:
-    name: Backend Tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: backend/requirements*.txt
-
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install -r agentcore/requirements.txt
-          pip install pytest pytest-cov
-
-      - name: Run tests
-        run: pytest tests/ -v --cov=src --cov-report=term-missing
-
-  cdk-synth:
-    name: CDK Synth Check
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: cdk
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: cdk/requirements.txt
-
-      - name: Install CDK dependencies
-        run: |
-          npm install -g aws-cdk
-          pip install -r requirements.txt
-          pip install pytest
-
-      - name: Run CDK tests
-        run: pytest tests/ -v
-
-      - name: CDK Synth
-        run: cdk synth --context jravan=true
-        env:
-          AWS_DEFAULT_REGION: ap-northeast-1
-
-  # デプロイジョブ（すべてのテストが成功した後に実行）
+  # CDKデプロイジョブ
   deploy-cdk:
     name: Deploy CDK Stacks
-    needs: [frontend-test, backend-test, cdk-synth]
+    needs: [ci]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 30
+    if: |
+      github.ref == 'refs/heads/main' && 
+      github.repository == 'foie0222/baken-kaigi' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
 
     steps:
       - uses: actions/checkout@v4
@@ -131,7 +48,7 @@ jobs:
           cache-dependency-path: cdk/requirements.txt
 
       - name: Install CDK
-        run: npm install -g aws-cdk
+        run: npm install -g aws-cdk@2
 
       - name: Install Python dependencies
         run: pip install -r requirements.txt
@@ -141,11 +58,27 @@ jobs:
         run: cdk deploy --all --context jravan=true --require-approval never
         working-directory: cdk
 
+      - name: Output CDK deployment summary
+        run: |
+          echo "## CDK Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Deployment completed at $(date)" >> $GITHUB_STEP_SUMMARY
+          echo "- AWS Region: ap-northeast-1" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Deployed Stacks" >> $GITHUB_STEP_SUMMARY
+          cdk ls --context jravan=true >> $GITHUB_STEP_SUMMARY
+        working-directory: cdk
+
+  # AgentCoreデプロイジョブ
   deploy-agentcore:
     name: Deploy AgentCore
-    needs: [frontend-test, backend-test, cdk-synth, deploy-cdk]
+    needs: [ci, deploy-cdk]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 15
+    if: |
+      github.ref == 'refs/heads/main' && 
+      github.repository == 'foie0222/baken-kaigi' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
 
     steps:
       - uses: actions/checkout@v4
@@ -160,10 +93,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
 
       - name: Install AgentCore CLI
         run: pip install bedrock-agentcore-starter-toolkit
 
+      - name: Verify AgentCore configuration
+        run: |
+          if [ ! -f .bedrock_agentcore.yaml ]; then
+            echo "Error: .bedrock_agentcore.yaml not found"
+            exit 1
+          fi
+        working-directory: backend/agentcore
+
       - name: Deploy AgentCore
         run: agentcore deploy
+        working-directory: backend/agentcore
+
+      - name: Output AgentCore deployment summary
+        run: |
+          echo "## AgentCore Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Deployment completed at $(date)" >> $GITHUB_STEP_SUMMARY
+          echo "- AWS Region: ap-northeast-1" >> $GITHUB_STEP_SUMMARY
         working-directory: backend/agentcore


### PR DESCRIPTION
## Summary
- mainブランチへのpush時に、CDKスタックとAgentCoreを自動デプロイするGitHub Actionsワークフローを追加
- OIDC認証を使用してAWSへセキュアにアクセス
- すべてのテスト（frontend, backend, cdk-synth）が成功した後にのみデプロイを実行

## 変更内容
- `.github/workflows/deploy.yml` を新規作成

## 事前準備（マージ前に必要）
1. AWS IAM OIDC Identity Providerの作成
   - Provider URL: `https://token.actions.githubusercontent.com`
   - Audience: `sts.amazonaws.com`

2. IAM Role `github-actions-deploy-role` の作成
   - Trust Policy: mainブランチのみに制限
   - 必要な権限: CloudFormation, Lambda, API Gateway, DynamoDB, IAM, S3, EC2, SSM, Logs, Bedrock, Bedrock-AgentCore

3. GitHub Secrets の設定
   - `AWS_DEPLOY_ROLE_ARN`: 作成したIAM RoleのARN

## Test plan
- [ ] GitHub Secretsに`AWS_DEPLOY_ROLE_ARN`を設定
- [ ] PRをmainにマージ
- [ ] GitHub ActionsでCIが成功することを確認
- [ ] CDKデプロイが実行されることを確認
- [ ] AgentCoreデプロイが実行されることを確認
- [ ] AWSコンソールでスタック更新を確認

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)