### PR TITLE
fix: AgentCore設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ jravan-api/.env
 # Bedrock AgentCore
 .bedrock_agentcore/
 .bedrock_agentcore.yaml
+!backend/agentcore/.bedrock_agentcore.yaml
 
 # uv lock file
 uv.lock

--- a/backend/agentcore/.bedrock_agentcore.yaml
+++ b/backend/agentcore/.bedrock_agentcore.yaml
@@ -1,0 +1,24 @@
+# Bedrock AgentCore Configuration
+# Generated for baken-kaigi AI Agent
+
+# Agent configuration
+agent:
+  name: baken-kaigi-agent
+  entrypoint: agent.py
+  requirements_file: requirements.txt
+
+# Deployment configuration
+deployment:
+  type: direct_code_deploy
+  runtime: PYTHON_3_12
+  region: ap-northeast-1
+
+# Runtime configuration
+runtime:
+  idle_timeout: 900
+  max_lifetime: 28800
+
+# Features
+features:
+  otel_enabled: true
+  memory_enabled: false


### PR DESCRIPTION
## Summary
- デプロイワークフローで必要な `.bedrock_agentcore.yaml` を追加
- `.gitignore` に例外を追加してこのファイルをトラッキング可能に

## Configuration
- Agent name: `baken-kaigi-agent`
- Runtime: Python 3.12
- Region: ap-northeast-1
- Deployment type: direct_code_deploy

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds with AgentCore deployment

## Related
- Fixes the Deploy AgentCore step failure in #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)