### PR TITLE
fix: GitHub OIDC スタックの Copilot レビュー指摘に対応

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -11,8 +11,9 @@ Usage:
     # 既存 VPC を使用する場合
     cdk deploy --all --context jravan=true --context vpc_id=vpc-xxxxxxxxx
 
-    # GitHub OIDC スタックのみデプロイ
-    cdk deploy GitHubOidcStack
+    # GitHub OIDC スタックをデプロイ（初回セットアップ時のみ）
+    # 注意: このスタックは明示的に github_oidc=true を指定した場合のみデプロイされます
+    cdk deploy GitHubOidcStack --context github_oidc=true
 """
 import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
@@ -25,6 +26,7 @@ app = cdk.App()
 
 # コンテキストから設定を取得
 use_jravan = app.node.try_get_context("jravan") == "true"
+use_github_oidc = app.node.try_get_context("github_oidc") == "true"
 vpc_id = app.node.try_get_context("vpc_id")
 
 # 環境設定
@@ -33,12 +35,14 @@ env = cdk.Environment(
     region="ap-northeast-1",
 )
 
-# GitHub OIDC スタック（常に作成）
-GitHubOidcStack(
-    app,
-    "GitHubOidcStack",
-    env=env,
-)
+# GitHub OIDC スタック（明示的に有効化された場合のみ）
+# 初回セットアップ時: cdk deploy GitHubOidcStack --context github_oidc=true
+if use_github_oidc:
+    GitHubOidcStack(
+        app,
+        "GitHubOidcStack",
+        env=env,
+    )
 
 if use_jravan:
     # ========================================

--- a/cdk/tests/test_github_oidc_stack.py
+++ b/cdk/tests/test_github_oidc_stack.py
@@ -1,0 +1,182 @@
+"""GitHub OIDC Stack テスト."""
+import sys
+from pathlib import Path
+
+import pytest
+
+# プロジェクトルート（cdk/）をパスに追加
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture
+def template():
+    """CloudFormationテンプレートを生成."""
+    import aws_cdk as cdk
+    from aws_cdk import assertions
+
+    from stacks.github_oidc_stack import GitHubOidcStack
+
+    app = cdk.App()
+    stack = GitHubOidcStack(
+        app,
+        "TestGitHubOidcStack",
+        env=cdk.Environment(account="123456789012", region="ap-northeast-1"),
+    )
+    return assertions.Template.from_stack(stack)
+
+
+class TestGitHubOidcStack:
+    """GitHub OIDCスタックのテスト."""
+
+    def test_oidc_provider_created(self, template):
+        """OIDC Providerが作成されること."""
+        # OpenIdConnectProvider はカスタムリソースで作成される
+        template.has_resource_properties(
+            "Custom::AWSCDKOpenIdConnectProvider",
+            {
+                "Url": "https://token.actions.githubusercontent.com",
+                "ClientIDList": ["sts.amazonaws.com"],
+            },
+        )
+
+    def test_oidc_provider_thumbprints(self, template):
+        """OIDC Providerに正しいthumbprintsが設定されること."""
+        template.has_resource_properties(
+            "Custom::AWSCDKOpenIdConnectProvider",
+            {
+                "ThumbprintList": [
+                    "6938fd4d98bab03faadb97b34396831e3780aea1",
+                    "1b511abead59b0b54b0a1c8232661093315d1fca",
+                ],
+            },
+        )
+
+    def test_iam_role_created(self, template):
+        """IAM Roleが作成されること."""
+        template.has_resource_properties(
+            "AWS::IAM::Role",
+            {
+                "RoleName": "github-actions-deploy-role",
+                "Description": "IAM Role for GitHub Actions CDK/AgentCore deployment",
+            },
+        )
+
+    def test_iam_role_trust_policy_conditions(self, template):
+        """IAM Roleの信頼ポリシーに正しい条件が設定されること."""
+        template.has_resource_properties(
+            "AWS::IAM::Role",
+            {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": "sts:AssumeRoleWithWebIdentity",
+                            "Condition": {
+                                "StringEquals": {
+                                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                                    "token.actions.githubusercontent.com:sub": "repo:foie0222/baken-kaigi:ref:refs/heads/main",
+                                },
+                            },
+                            "Effect": "Allow",
+                        }
+                    ],
+                },
+            },
+        )
+
+    def test_iam_role_assume_bootstrap_roles_policy(self, template):
+        """Bootstrap ロールへの AssumeRole 権限が設定されること."""
+        template.has_resource_properties(
+            "AWS::IAM::Policy",
+            {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Sid": "AssumeBootstrapRoles",
+                            "Action": "sts:AssumeRole",
+                            "Effect": "Allow",
+                            "Resource": "arn:aws:iam::123456789012:role/cdk-hnb659fds-*",
+                        },
+                        {
+                            "Sid": "BedrockAgentCore",
+                        },
+                    ],
+                },
+            },
+        )
+
+    def test_iam_role_bedrock_policy(self, template):
+        """Bedrock/AgentCore 権限が設定されること."""
+        template.has_resource_properties(
+            "AWS::IAM::Policy",
+            {
+                "PolicyDocument": {
+                    "Statement": [
+                        {
+                            "Sid": "AssumeBootstrapRoles",
+                        },
+                        {
+                            "Sid": "BedrockAgentCore",
+                            "Action": ["bedrock:*", "bedrock-agentcore:*"],
+                            "Effect": "Allow",
+                            "Resource": "*",
+                        },
+                    ],
+                },
+            },
+        )
+
+    def test_deploy_role_arn_output(self, template):
+        """DeployRoleArn出力が存在すること."""
+        template.has_output(
+            "DeployRoleArn",
+            {
+                "Export": {"Name": "GitHubActionsDeployRoleArn"},
+            },
+        )
+
+    def test_oidc_provider_arn_output(self, template):
+        """OidcProviderArn出力が存在すること."""
+        template.has_output(
+            "OidcProviderArn",
+            {
+                "Export": {"Name": "GitHubOidcProviderArn"},
+            },
+        )
+
+
+class TestGitHubOidcStackCustomOwnerRepo:
+    """カスタム owner/repo 設定のテスト."""
+
+    def test_custom_owner_repo(self):
+        """カスタムの owner/repo を設定できること."""
+        import aws_cdk as cdk
+        from aws_cdk import assertions
+
+        from stacks.github_oidc_stack import GitHubOidcStack
+
+        app = cdk.App()
+        stack = GitHubOidcStack(
+            app,
+            "TestCustomStack",
+            github_owner="custom-org",
+            github_repo="custom-repo",
+            env=cdk.Environment(account="123456789012", region="ap-northeast-1"),
+        )
+        template = assertions.Template.from_stack(stack)
+
+        template.has_resource_properties(
+            "AWS::IAM::Role",
+            {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Condition": {
+                                "StringEquals": {
+                                    "token.actions.githubusercontent.com:sub": "repo:custom-org/custom-repo:ref:refs/heads/main",
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
+        )


### PR DESCRIPTION
## Summary
PR #115 の Copilot レビューコメントに対応します。

## Changes

### 1. Context フラグで有効化
- `github_oidc=true` コンテキストフラグで明示的に有効化
- `cdk deploy --all` でも意図せずデプロイされない

### 2. Thumbprints を修正
- 正しい DigiCert 証明書のフィンガープリントを設定
- 更新手順のコメントを追加

### 3. StringLike → StringEquals
- ワイルドカード未使用のため完全一致に変更

### 4. 権限を最小化
- 広範な `*` 権限を削除
- CDK Bootstrap ロール (`cdk-hnb659fds-*`) への AssumeRole のみ
- AgentCore 用 Bedrock 権限は維持

### 5. STS resources をアカウント固定
- `arn:aws:iam::*:role/cdk-*` → `arn:aws:iam::{account}:role/cdk-hnb659fds-*`

### 6. テスト追加
- OIDC Provider、IAM Role、信頼ポリシー、出力の検証テスト

## Test plan
- [x] テスト追加・パス (`pytest tests/test_github_oidc_stack.py`)
- [x] `cdk synth --context jravan=true` で OIDC スタックが含まれないことを確認
- [x] `cdk synth GitHubOidcStack --context github_oidc=true` で正しいテンプレート生成

## Related
- Addresses review comments on PR #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)