### PR TITLE
fix: AgentCore デプロイに uv をインストール

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,8 +95,13 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: '0.4.30'
+
+      - name: Verify uv installation
+        run: uv --version
 
       - name: Install AgentCore CLI
         run: pip install bedrock-agentcore-starter-toolkit
@@ -110,9 +115,7 @@ jobs:
         working-directory: backend/agentcore
 
       - name: Deploy AgentCore
-        run: |
-          source $HOME/.local/bin/env
-          agentcore deploy
+        run: agentcore deploy
         working-directory: backend/agentcore
 
       - name: Output AgentCore deployment summary


### PR DESCRIPTION
## Summary
AgentCore CLI の direct_code_deploy デプロイタイプには `uv` が必要です。

## Changes
- `uv` のインストールステップを追加
- Deploy AgentCore ステップで `uv` を PATH に追加

## Test plan
- [ ] CI passes
- [ ] Deploy workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)