### PR TITLE
fix: AgentCore deploy時のuv仮想環境エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Deploy AgentCore
         run: agentcore deploy
         working-directory: backend/agentcore
+        env:
+          UV_SYSTEM_PYTHON: '1'
 
       - name: Output AgentCore deployment summary
         run: |


### PR DESCRIPTION
## Summary
- UV_SYSTEM_PYTHON=1 環境変数を設定してシステムPythonを使用するように変更
- agentcore deploy が内部で uv を呼び出す際に仮想環境が見つからないエラーを回避

## 関連Issue
- #112

## Test plan
- [ ] GitHub Actions deploy workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)