### PR TITLE
feat: Claude Code の enabledPlugins 設定を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に `enabledPlugins` セクションを追加
- 以下のプラグインを有効化:
  - frontend-design@claude-plugins-official
  - code-review@claude-plugins-official
  - playwright@claude-plugins-official
  - ralph-loop@claude-plugins-official

## Test plan
- [x] PRの差分が `enabledPlugins` セクションのみであることを確認
- [x] JSON形式が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)