### PR TITLE
feat: 調教データ取得APIエンドポイント追加 (#80)

### DIFF
--- a/backend/src/domain/ports/__init__.py
+++ b/backend/src/domain/ports/__init__.py
@@ -14,6 +14,8 @@ from .race_data_provider import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 
@@ -35,5 +37,7 @@ __all__ = [
     "RaceData",
     "RaceDataProvider",
     "RunnerData",
+    "TrainingRecordData",
+    "TrainingSummaryData",
     "WeightData",
 ]

--- a/backend/src/domain/ports/race_data_provider.py
+++ b/backend/src/domain/ports/race_data_provider.py
@@ -152,6 +152,32 @@ class JockeyInfoData:
 
 
 @dataclass(frozen=True)
+class TrainingRecordData:
+    """調教データ."""
+
+    date: str  # YYYYMMDD形式
+    course: str  # 栗東CW, 美浦南W など
+    course_condition: str  # 良/稍/重/不
+    distance: int  # メートル
+    time: str  # 例: "52.3"
+    last_3f: str | None = None  # 例: "12.5"
+    last_1f: str | None = None  # 例: "12.0"
+    training_type: str | None = None  # 馬なり/一杯/強め など
+    partner_horse: str | None = None  # 併せ馬
+    evaluation: str | None = None  # A/B/C など
+    comment: str | None = None
+
+
+@dataclass(frozen=True)
+class TrainingSummaryData:
+    """調教サマリー."""
+
+    recent_trend: str  # 上昇/平行/下降
+    average_time: str | None = None
+    best_time: str | None = None
+
+
+@dataclass(frozen=True)
 class JockeyStatsDetailData:
     """騎手成績統計データ."""
 
@@ -330,5 +356,24 @@ class RaceDataProvider(ABC):
 
         Returns:
             過去成績データのリスト（新しい順）
+        """
+        pass
+
+    @abstractmethod
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する.
+
+        Args:
+            horse_id: 馬コード
+            limit: 取得件数（デフォルト5、最大10）
+            days: 直近N日分（デフォルト30）
+
+        Returns:
+            調教データのリストとサマリーのタプル
         """
         pass

--- a/backend/tests/api/handlers/test_consultation.py
+++ b/backend/tests/api/handlers/test_consultation.py
@@ -25,6 +25,8 @@ from src.domain.ports import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 from src.domain.value_objects import BetSelection, HorseNumbers, Money
@@ -156,6 +158,15 @@ class MockRaceDataProvider(RaceDataProvider):
     ) -> list[HorsePerformanceData]:
         """馬の過去成績を取得する（モック実装）."""
         return []
+
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する（モック実装）."""
+        return [], None
 
 
 class MockAIClient(AIClient):

--- a/backend/tests/api/handlers/test_horses.py
+++ b/backend/tests/api/handlers/test_horses.py
@@ -1,7 +1,7 @@
 """馬API ハンドラーのテスト."""
 import json
 
-from src.api.handlers.horses import get_horse_performances
+from src.api.handlers.horses import get_horse_performances, get_horse_training
 
 
 class TestGetHorsePerformances:
@@ -81,3 +81,124 @@ class TestGetHorsePerformances:
         }
         response = get_horse_performances(event, None)
         assert response["statusCode"] == 400
+
+
+class TestGetHorseTraining:
+    """get_horse_training のテスト."""
+
+    def test_正常取得(self) -> None:
+        """馬の調教データを正常に取得できる."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": None,
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 200
+        body = response.get("body")
+        assert body is not None
+        data = json.loads(body)
+        assert "horse_id" in data
+        assert "horse_name" in data
+        assert "training_records" in data
+        assert "training_summary" in data
+        assert isinstance(data["training_records"], list)
+
+    def test_limitパラメータ(self) -> None:
+        """limit パラメータでレコード数を制限できる."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": {"limit": "3"},
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 200
+        data = json.loads(response["body"])
+        assert len(data["training_records"]) <= 3
+
+    def test_無効なlimit(self) -> None:
+        """limit が無効な場合はエラーを返す."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": {"limit": "abc"},
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 400
+
+    def test_limit範囲外(self) -> None:
+        """limit が範囲外の場合はエラーを返す."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": {"limit": "15"},
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 400
+
+    def test_daysパラメータ(self) -> None:
+        """days パラメータで対象期間を指定できる."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": {"days": "14"},
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 200
+        data = json.loads(response["body"])
+        assert isinstance(data["training_records"], list)
+
+    def test_無効なdays(self) -> None:
+        """days が無効な場合はエラーを返す."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": {"days": "abc"},
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 400
+
+    def test_days範囲外(self) -> None:
+        """days が範囲外の場合はエラーを返す."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": {"days": "500"},
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 400
+
+    def test_horse_id未指定(self) -> None:
+        """horse_id が指定されていない場合はエラーを返す."""
+        event = {
+            "pathParameters": {},
+            "queryStringParameters": None,
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 400
+
+    def test_training_recordsの構造(self) -> None:
+        """training_records の各レコードが必要なフィールドを持つ."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": None,
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 200
+        data = json.loads(response["body"])
+        if data["training_records"]:
+            record = data["training_records"][0]
+            assert "date" in record
+            assert "course" in record
+            assert "course_condition" in record
+            assert "distance" in record
+            assert "time" in record
+            assert "evaluation" in record
+
+    def test_training_summaryの構造(self) -> None:
+        """training_summary が必要なフィールドを持つ."""
+        event = {
+            "pathParameters": {"horse_id": "horse_0001"},
+            "queryStringParameters": None,
+        }
+        response = get_horse_training(event, None)
+        assert response["statusCode"] == 200
+        data = json.loads(response["body"])
+        if data["training_summary"]:
+            summary = data["training_summary"]
+            assert "recent_trend" in summary
+            assert "average_time" in summary
+            assert "best_time" in summary

--- a/backend/tests/api/handlers/test_races.py
+++ b/backend/tests/api/handlers/test_races.py
@@ -17,6 +17,8 @@ from src.domain.ports import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 
@@ -124,6 +126,15 @@ class MockRaceDataProvider(RaceDataProvider):
     ) -> list[HorsePerformanceData]:
         """馬の過去成績を取得する（モック実装）."""
         return []
+
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する（モック実装）."""
+        return [], None
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/application/use_cases/test_get_race_detail.py
+++ b/backend/tests/application/use_cases/test_get_race_detail.py
@@ -15,6 +15,8 @@ from src.domain.ports import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 
@@ -107,6 +109,15 @@ class MockRaceDataProvider(RaceDataProvider):
     ) -> list[HorsePerformanceData]:
         """馬の過去成績を取得する（モック実装）."""
         return []
+
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する（モック実装）."""
+        return [], None
 
 
 class TestGetRaceDetailUseCase:

--- a/backend/tests/application/use_cases/test_get_race_list.py
+++ b/backend/tests/application/use_cases/test_get_race_list.py
@@ -16,6 +16,8 @@ from src.domain.ports import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 
@@ -116,6 +118,15 @@ class MockRaceDataProvider(RaceDataProvider):
     ) -> list[HorsePerformanceData]:
         """馬の過去成績を取得する（モック実装）."""
         return []
+
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する（モック実装）."""
+        return [], None
 
 
 class TestGetRaceListUseCase:

--- a/backend/tests/application/use_cases/test_start_consultation.py
+++ b/backend/tests/application/use_cases/test_start_consultation.py
@@ -23,6 +23,8 @@ from src.domain.ports import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 from src.domain.value_objects import BetSelection, HorseNumbers, Money
@@ -157,6 +159,15 @@ class MockRaceDataProvider(RaceDataProvider):
     ) -> list[HorsePerformanceData]:
         """馬の過去成績を取得する（モック実装）."""
         return []
+
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する（モック実装）."""
+        return [], None
 
 
 class MockAIClient(AIClient):

--- a/backend/tests/domain/ports/test_race_data_provider.py
+++ b/backend/tests/domain/ports/test_race_data_provider.py
@@ -14,6 +14,8 @@ from src.domain.ports import (
     RaceData,
     RaceDataProvider,
     RunnerData,
+    TrainingRecordData,
+    TrainingSummaryData,
     WeightData,
 )
 
@@ -160,6 +162,15 @@ class MockRaceDataProvider(RaceDataProvider):
     ) -> list[HorsePerformanceData]:
         """馬の過去成績を取得する（モック実装）."""
         return []
+
+    def get_horse_training(
+        self,
+        horse_id: str,
+        limit: int = 5,
+        days: int = 30,
+    ) -> tuple[list[TrainingRecordData], TrainingSummaryData | None]:
+        """馬の調教データを取得する（モック実装）."""
+        return [], None
 
 
 class TestRaceDataProviderInterface:

--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -290,6 +290,19 @@ class BakenKaigiApiStack(Stack):
             **lambda_common_props,
         )
 
+        get_horse_training_fn = lambda_.Function(
+            self,
+            "GetHorseTrainingFunction",
+            handler="src.api.handlers.horses.get_horse_training",
+            code=lambda_.Code.from_asset(
+                str(project_root / "backend"),
+                exclude=["tests", ".venv", ".git", "__pycache__", "*.pyc"],
+            ),
+            function_name="baken-kaigi-get-horse-training",
+            description="馬の調教データ取得",
+            **lambda_common_props,
+        )
+
         # 騎手API
         get_jockey_info_fn = lambda_.Function(
             self,
@@ -402,6 +415,12 @@ class BakenKaigiApiStack(Stack):
         horse_performances = horse.add_resource("performances")
         horse_performances.add_method(
             "GET", apigw.LambdaIntegration(get_horse_performances_fn), api_key_required=True
+        )
+
+        # /horses/{horse_id}/training
+        horse_training = horse.add_resource("training")
+        horse_training.add_method(
+            "GET", apigw.LambdaIntegration(get_horse_training_fn), api_key_required=True
         )
 
         # /jockeys

--- a/cdk/tests/test_api_stack.py
+++ b/cdk/tests/test_api_stack.py
@@ -25,8 +25,8 @@ class TestApiStack:
     """APIスタックのテスト."""
 
     def test_lambda_functions_created(self, template):
-        """Lambda関数が14個作成されること."""
-        template.resource_count_is("AWS::Lambda::Function", 14)
+        """Lambda関数が15個作成されること."""
+        template.resource_count_is("AWS::Lambda::Function", 15)
 
     def test_lambda_layer_created(self, template):
         """Lambda Layerが1個作成されること."""
@@ -157,5 +157,12 @@ class TestApiStack:
             {
                 "FunctionName": "baken-kaigi-get-horse-performances",
                 "Handler": "src.api.handlers.horses.get_horse_performances",
+            },
+        )
+        template.has_resource_properties(
+            "AWS::Lambda::Function",
+            {
+                "FunctionName": "baken-kaigi-get-horse-training",
+                "Handler": "src.api.handlers.horses.get_horse_training",
             },
         )


### PR DESCRIPTION
## Summary
- GET /horses/{horse_id}/training エンドポイントを追加
- 馬の調教データ（追い切りタイム、コース、調教評価等）を取得するAPIを実装
- `TrainingRecordData` と `TrainingSummaryData` データクラスを追加

## Changes
- `backend/src/domain/ports/race_data_provider.py`: TrainingRecordData, TrainingSummaryData追加
- `backend/src/api/handlers/horses.py`: get_horse_training ハンドラー追加
- `backend/src/infrastructure/providers/mock_race_data_provider.py`: モック実装追加
- `backend/src/infrastructure/providers/jravan_race_data_provider.py`: JRA-VAN API実装追加
- `cdk/stacks/api_stack.py`: Lambda関数とAPIルート追加
- テストファイル: 全MockRaceDataProviderに新メソッド追加

## Test plan
- [ ] `pytest backend/tests/api/handlers/test_horses.py` で新しいテストが全てパスすること
- [ ] CDKテストでLambda関数数が15であること

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)