### PR TITLE
fix: hookのsedパターンをBSD sed互換に修正

### DIFF
--- a/.claude/hooks/pre-tool-use-block-pr-operations.sh
+++ b/.claude/hooks/pre-tool-use-block-pr-operations.sh
@@ -62,7 +62,7 @@ if echo "$COMMAND" | grep -qE '(^|[;&|])[[:space:]]*([[:alnum:]/._~-]+/)?gh[[:sp
 
   # コマンドに cd が含まれる場合、そのディレクトリに移動してから処理を実行
   if echo "$COMMAND" | grep -qE '^[[:space:]]*cd[[:space:]]+'; then
-    TARGET_DIR=$(echo "$COMMAND" | sed -n 's/^[[:space:]]*cd[[:space:]]\+\([^;&|]*\).*/\1/p' | sed 's/[[:space:]]*$//')
+    TARGET_DIR=$(echo "$COMMAND" | sed -n 's/^[[:space:]]*cd[[:space:]][[:space:]]*\([^;&|]*\).*/\1/p' | sed 's/[[:space:]]*$//')
     if [ -n "$TARGET_DIR" ] && [ -d "$TARGET_DIR" ]; then
       cd "$TARGET_DIR" || exit 2
     fi


### PR DESCRIPTION
## Summary
- macOSのBSD sedでは`\+`が動作しないため、`[[:space:]][[:space:]]*`に変更
- これにより`cd /path && gh pr merge`形式のコマンドが正しく処理される

## Test plan
- [ ] `cd /path && gh pr merge`形式でCopilotレビューなしのマージがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)