### PR TITLE
refactor: ec2-syncスキルからsync/sync-fromコマンドを削除

### DIFF
--- a/.claude/docs/aws-operations.md
+++ b/.claude/docs/aws-operations.md
@@ -31,8 +31,10 @@ npx cdk deploy --all --context jravan=true --require-approval never
 
 EC2（JRA-VAN API）の操作は以下のスキルを使用:
 
-- `/ec2-sync` - データ同期・EC2操作の簡易インターフェース
+- `/ec2-sync` - EC2操作の簡易インターフェース
 - `/jravan-ec2` - 詳細なSSMコマンドリファレンス
+
+> **Note**: JRA-VANデータの同期はPC-KEIBAソフトで行います。
 
 ### よく使うコマンド
 
@@ -46,11 +48,7 @@ aws ec2 describe-instances \
 /ec2-sync status
 
 # ファイル送信
-/ec2-sync upload sync_jvlink.py
-
-# データ同期
-/ec2-sync sync
-/ec2-sync sync-from 20260101
+/ec2-sync upload main.py
 
 # ログ確認
 /ec2-sync logs

--- a/.claude/skills/ec2-sync/SKILL.md
+++ b/.claude/skills/ec2-sync/SKILL.md
@@ -188,7 +188,7 @@ aws ssm describe-instance-information \
 
 ## 参照
 
-- **CLAUDE.md**: `main/CLAUDE.md` の「EC2操作」セクション
+- **AWS操作ガイド**: `.claude/docs/aws-operations.md` の「EC2操作」セクション
 - **AWS SSM**: https://docs.aws.amazon.com/systems-manager/
 - **CloudWatch Logs**: https://docs.aws.amazon.com/cloudwatch/
 


### PR DESCRIPTION
## Summary
- データ同期はPC-KEIBAソフトで行うため、`sync`と`sync-from`コマンドを削除
- `sync_jvlink.py`はEC2上に存在せず、使われていないことを確認済み

## 残る機能
- `upload`: ファイルをEC2に送信
- `logs`: ログ確認
- `status`: EC2インスタンス状態確認

## Test plan
- [ ] `/ec2-sync status`が正常に動作することを確認
- [ ] `/ec2-sync upload`が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)