### PR TITLE
docs: ホスティング構成図をMermaidで刷新

### DIFF
--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -42,32 +42,68 @@
 
 ## 構成図
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                    bakenkaigi.com                       │
-│                   （お名前.com で取得）                   │
-└─────────────────────────────────────────────────────────┘
-                            │
-                            ▼
-┌─────────────────────────────────────────────────────────┐
-│                      Cloudflare                         │
-│                    （DNS / 無料プラン）                   │
-└─────────────────────────────────────────────────────────┘
-                   │                    │
-                   ▼                    ▼
-        ┌──────────────────┐  ┌──────────────────┐
-        │  bakenkaigi.com  │  │ api.bakenkaigi.  │
-        │                  │  │     com          │
-        │    (CNAME)       │  │    (CNAME)       │
-        └────────┬─────────┘  └────────┬─────────┘
-                 │                     │
-                 ▼                     ▼
-        ┌──────────────────┐  ┌──────────────────┐
-        │   AWS Amplify    │  │  API Gateway     │
-        │                  │  │                  │
-        │  - React         │  │  - Lambda        │
-        │  - 自動デプロイ   │  │  - Python        │
-        └──────────────────┘  └──────────────────┘
+```mermaid
+flowchart TB
+    subgraph registrar["📝 お名前.com"]
+        domain["🌐 bakenkaigi.com"]
+    end
+
+    subgraph cloudflare["☁️ Cloudflare DNS"]
+        direction LR
+        root["@ (ルート)<br/>CNAME"]
+        api_record["api<br/>CNAME"]
+    end
+
+    subgraph aws["☁️ AWS"]
+        subgraph frontend["フロントエンド"]
+            amplify["📱 Amplify<br/>• React + TypeScript<br/>• 自動デプロイ<br/>• SSL自動管理"]
+        end
+
+        subgraph backend["バックエンドAPI"]
+            apigw["🔌 API Gateway<br/>REST API"]
+            lambda["⚡ Lambda<br/>Python"]
+
+            subgraph ai["AI相談機能"]
+                agentcore["🤖 Bedrock<br/>AgentCore"]
+            end
+        end
+
+        subgraph ec2zone["JRA-VAN データ基盤"]
+            ec2["🖥️ EC2 Windows<br/>FastAPI Server"]
+            subgraph dataLayer[" "]
+                direction LR
+                jvlink["📊 JV-Link<br/>JRA-VAN Data Lab."]
+                postgres["🗄️ PostgreSQL<br/>PC-KEIBA Database"]
+            end
+        end
+    end
+
+    domain --> cloudflare
+    root -->|"bakenkaigi.com"| amplify
+    api_record -->|"api.bakenkaigi.com"| apigw
+    apigw --> lambda
+    lambda --> agentcore
+    lambda -->|"直接API"| ec2
+    agentcore -->|"ツール経由"| ec2
+    ec2 --> postgres
+    jvlink -->|"データ同期"| postgres
+
+    style registrar fill:#f5f5f5,stroke:#333,stroke-width:2px
+    style cloudflare fill:#f48120,stroke:#333,stroke-width:2px,color:#fff
+    style aws fill:#232f3e,stroke:#ff9900,stroke-width:2px,color:#fff
+    style frontend fill:#1a73e8,stroke:#fff,stroke-width:1px,color:#fff
+    style backend fill:#1a73e8,stroke:#fff,stroke-width:1px,color:#fff
+    style ai fill:#7b42bc,stroke:#fff,stroke-width:1px,color:#fff
+    style ec2zone fill:#2e7d32,stroke:#fff,stroke-width:1px,color:#fff
+    style dataLayer fill:#2e7d32,stroke:none
+    style domain fill:#fff,stroke:#333
+    style amplify fill:#ff9900,stroke:#fff,color:#000
+    style apigw fill:#ff9900,stroke:#fff,color:#000
+    style lambda fill:#ff9900,stroke:#fff,color:#000
+    style agentcore fill:#9c27b0,stroke:#fff,color:#fff
+    style ec2 fill:#4caf50,stroke:#fff,color:#fff
+    style postgres fill:#336791,stroke:#fff,color:#fff
+    style jvlink fill:#1976d2,stroke:#fff,color:#fff
 ```
 
 ## 備考


### PR DESCRIPTION
## Summary
- ASCII図からMermaid flowchartに変更
- バックエンド構成を詳細化（Lambda → AgentCore, Lambda → EC2）
- JRA-VANデータ基盤の構成を追加（EC2/FastAPI, PostgreSQL, JV-Link）

## Test plan
- [ ] GitHubでMermaid図が正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)