### PR TITLE
chore: Ruff line-length を100から120に変更

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ warn_unused_ignores = true
 
 [tool.ruff]
 target-version = "py311"
-line-length = 100
+line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]


### PR DESCRIPTION
## Summary
- Ruffの行長制限を100から120に緩和

## Test plan
- [x] `ruff check`でエラーが解消されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)