### PR TITLE
fix: DynamoDBクライアントにリージョンを明示指定

### DIFF
--- a/backend/agentcore/tools/ai_prediction.py
+++ b/backend/agentcore/tools/ai_prediction.py
@@ -9,11 +9,14 @@ import boto3
 from botocore.exceptions import ClientError
 from strands import tool
 
+# AWSリージョン（AgentCore環境ではAWS_REGION未設定の場合があるため明示指定）
+AWS_REGION = os.environ.get("AWS_REGION", "ap-northeast-1")
+
 
 def get_dynamodb_table():
     """DynamoDB テーブルを取得."""
     table_name = os.environ.get("AI_PREDICTIONS_TABLE_NAME", "baken-kaigi-ai-predictions")
-    dynamodb = boto3.resource("dynamodb")
+    dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
     return dynamodb.Table(table_name)
 
 


### PR DESCRIPTION
## Summary
- AgentCore環境でAWS_REGION未設定によりDynamoDBアクセスエラーが発生していた問題を修正
- boto3.resource()にregion_nameを明示的に指定

## 背景
AI指数ツールでDynamoDBにアクセスする際、「You must specify a region」エラーが発生していた。
AgentCore Runtime環境ではAWS_REGION環境変数が設定されていないため。

## Test plan
- [ ] AgentCoreデプロイ後、AI相談で「東京11RのAI指数を教えて」と質問
- [ ] エラーなくAI指数データが返ってくることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)