### PR TITLE
fix: レース詳細画面のボタン文言を修正

### DIFF
--- a/frontend/src/pages/RaceDetailPage.tsx
+++ b/frontend/src/pages/RaceDetailPage.tsx
@@ -376,7 +376,7 @@ export function RaceDetailPage() {
             className="btn-ai-confirm mt-3"
             onClick={() => navigate('/cart')}
           >
-            AIと一緒に確認する（{itemCount}件） →
+            カートを確認する（{itemCount}件） →
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
- レース詳細画面のボタン文言を「AIと一緒に確認する」→「カートを確認する」に変更
- 遷移先（カート画面）と文言を一致させ、ユーザーの期待と実際の動作のギャップを解消

## Before / After
| Before | After |
|--------|-------|
| AIと一緒に確認する（n件）→ | カートを確認する（n件）→ |

## Test plan
- [x] ユニットテスト通過
- [ ] 手動確認：レース詳細画面でカートに追加後、ボタン文言が「カートを確認する」になっていることを確認

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)