### PR TITLE
fix: VSCode git.autoRepositoryDetection設定をtrueに変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,7 +43,7 @@
 
   "errorLens.enabledDiagnosticLevels": ["error", "warning"],
 
-  "git.autoRepositoryDetection": "openEditors",
+  "git.autoRepositoryDetection": true,
 
   "search.exclude": {
     "**/node_modules": true,


### PR DESCRIPTION
## Summary
- git.autoRepositoryDetectionを`openEditors`から`true`に変更
- git worktree構成でもリポジトリが正しく検出されるように修正

## Test plan
- [x] VSCodeを再読み込みしてソース管理パネルでリポジトリが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)