### PR TITLE
refactor: デプロイワークフローからCI呼び出しを削除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,15 +10,9 @@ permissions:
   contents: read
 
 jobs:
-  # CIジョブを再利用
-  ci:
-    name: CI
-    uses: ./.github/workflows/ci.yml
-
   # CDKデプロイジョブ
   deploy-cdk:
     name: Deploy CDK Stacks
-    needs: [ci]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: |


### PR DESCRIPTION
## Summary
- デプロイワークフロー（deploy.yml）からCI呼び出しを削除
- PRでCI通過が必須のため、マージ後の重複実行を削除してデプロイを高速化

## 背景
現状の流れ：
1. PR作成 → ci.yml実行
2. CI通過 → マージ
3. mainにpush → deploy.yml → **ci.yml再実行** → CDKデプロイ

PRで既にCI通過済みなのに、マージ後にまたCIを実行していた。

## 変更内容
- `deploy.yml` から `ci` ジョブの呼び出しを削除
- `deploy-cdk` ジョブの `needs: [ci]` を削除

## Test plan
- [ ] PRでCIが通ることを確認
- [ ] マージ後、デプロイが直接実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)