### PR TITLE
docs: CLAUDE.mdのスキル記載をタスク別ワークフローに改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,11 +64,36 @@ cd backend && pytest
 - AWS操作: `.claude/docs/aws-operations.md`
 - Git運用: `.claude/docs/git-workflow.md`
 
-## スキル
+## タスク別ワークフロー
 
-- `/deploy-prep` - デプロイ前チェック実行
-- `/ec2-sync` - EC2データ同期
-- `/copilot-review` - PRレビュー対応
+### 新機能実装時
+`tdd-generator` エージェントを使用してTDD駆動で実装する。
+- Red → Green → Refactor サイクルを自動実行
+
+### API拡張時
+1. `/ddd-check` でドメイン設計との整合性を検証
+2. `/api-extend` で6段階ワークフロー実行（ports → provider → handler → Mock → テスト → フロント型 → UI）
+3. `frontend-mapper` エージェントでTypeScript型を自動生成
+
+### UI実装時
+- `/ui-component` でReact + Tailwind CSSパターンを適用
+- コンポーネント設計のベストプラクティスに従う
+
+### PR対応時
+- `/copilot-review` でGitHub Copilotレビューコメントを取得→修正→返信→解決
+
+### デプロイ前（必須）
+- `/deploy-prep` でチェックスクリプト実行（テスト、リント、CDK Synth検証）
+
+### Issue対応時
+- `/issue-to-task` でGitHub Issueからタスク分解・チェックリスト生成
+
+### EC2操作時
+- `/ec2-sync` でSSMコマンドを簡素化
+- `/jravan-ec2` でJRA-VAN APIへのファイル送信
+
+### コードベース調査時
+`Explore` エージェントを使用して効率的に調査する。
 
 ## 注意事項
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdの「スキル」セクションを「タスク別ワークフロー」に変更
- スキルとカスタムエージェントの利用シーンを明確化
- 未記載だったスキル・エージェントを追加

## 背景
スキルやカスタムエージェントがあまり使われていない問題を調査した結果、CLAUDE.mdの記載方法に改善の余地があることが判明。

**Before**: スキルの存在を列挙するだけ
**After**: 「いつ使うか」をタスク別に明記

## 変更内容
| タスク | スキル/エージェント |
|--------|---------------------|
| 新機能実装 | `tdd-generator` エージェント |
| API拡張 | `/ddd-check` → `/api-extend` → `frontend-mapper` |
| UI実装 | `/ui-component` |
| PR対応 | `/copilot-review` |
| デプロイ前 | `/deploy-prep` |
| Issue対応 | `/issue-to-task` |
| EC2操作 | `/ec2-sync`, `/jravan-ec2` |
| コードベース調査 | `Explore` エージェント |

## Test plan
- [ ] Claude Codeのセッションを新規開始し、スキル・エージェントの利用頻度を観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)