### PR TITLE
fix: ConsultationPage UI不具合を修正

### DIFF
--- a/frontend/src/pages/ConsultationPage.test.tsx
+++ b/frontend/src/pages/ConsultationPage.test.tsx
@@ -81,4 +81,52 @@ describe('ConsultationPage', () => {
       expect(sendButton).toBeInTheDocument()
     })
   })
+
+  describe('買い目グルーピング表示', () => {
+    it('買い目一覧のタイトルとレース情報が表示される', async () => {
+      render(<ConsultationPage />)
+
+      // 「買い目一覧」というタイトルが表示される
+      expect(await screen.findByText('買い目一覧')).toBeInTheDocument()
+
+      // レース情報が表示される（東京 1R）
+      expect(await screen.findByText('東京 1R')).toBeInTheDocument()
+    })
+
+    it('同一レースの複数買い目がグループ内にまとめて表示される', async () => {
+      // 同一レースに追加の買い目を追加
+      useCartStore.getState().addItem({
+        raceId: 'test-race-1',
+        raceName: 'テストレース',
+        raceVenue: '東京',
+        raceNumber: '1R',
+        betType: 'quinella',
+        betMethod: 'normal',
+        horseNumbers: [1, 2],
+        betDisplay: '1-2',
+        betCount: 1,
+        amount: 500,
+      })
+
+      render(<ConsultationPage />)
+
+      // 「買い目一覧」は1つだけ表示される（同一レースなのでグループは1つ）
+      const titles = await screen.findAllByText('買い目一覧')
+      expect(titles).toHaveLength(1)
+
+      // 2つの買い目が表示される
+      expect(await screen.findByText('単勝')).toBeInTheDocument()
+      expect(await screen.findByText('馬連')).toBeInTheDocument()
+      expect(await screen.findByText('1')).toBeInTheDocument()
+      expect(await screen.findByText('1-2')).toBeInTheDocument()
+    })
+
+    it('削除ボタンにアクセシビリティ属性が設定されている', async () => {
+      render(<ConsultationPage />)
+
+      const deleteButton = await screen.findByRole('button', { name: '買い目を削除' })
+      expect(deleteButton).toBeInTheDocument()
+      expect(deleteButton).toHaveAttribute('title', '買い目を削除')
+    })
+  })
 })

--- a/frontend/src/pages/ConsultationPage.tsx
+++ b/frontend/src/pages/ConsultationPage.tsx
@@ -314,7 +314,14 @@ export function ConsultationPage() {
                   </div>
                   <div className="bet-actions">
                     <button className="btn-edit" onClick={() => handleEditAmount(item.id, item.amount)}>変更</button>
-                    <button className="btn-delete" onClick={() => handleDeleteItem(item.id)}>×</button>
+                    <button
+                      className="btn-delete"
+                      onClick={() => handleDeleteItem(item.id)}
+                      aria-label="買い目を削除"
+                      title="買い目を削除"
+                    >
+                      ×
+                    </button>
                   </div>
                 </div>
               ))}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -9,6 +9,7 @@
     --color-alert-amber-bg: #fffbeb;
     --color-alert-red: #dc2626;
     --color-alert-red-bg: #fef2f2;
+    --color-alert-red-hover: #fecaca;
 
     /* 中立色: データの客観的表示 */
     --color-neutral-50: #f9fafb;
@@ -1841,7 +1842,7 @@ main {
 
 .btn-delete {
     padding: 6px 10px;
-    background: #ffebee;
+    background: var(--color-alert-red-bg);
     border: none;
     border-radius: 6px;
     font-size: 11px;
@@ -1850,5 +1851,5 @@ main {
 }
 
 .btn-delete:hover {
-    background: #fecaca;
+    background: var(--color-alert-red-hover);
 }


### PR DESCRIPTION
## Summary
- .bet-type を .bet-card-type にリネームして RaceDetailPage の券種セレクターとの衝突を回避
- raceNumber の重複「R」表示を修正（1RR → 1R）
- 買い目をレースごとにグループ化してテーブル形式で表示（モックに合わせた変更）

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] レース詳細ページで券種セレクターが深緑色でないことを確認
- [ ] AI相談ページでレース番号が「小倉 1R」（RRでない）で表示
- [ ] AI相談ページでレースごとにグループ化されて表示
- [ ] AI相談ページでテーブル形式でモックと同様の表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)