### PR TITLE
chore: CIワークフローからmainへのpushトリガーを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:  # 他のワークフローから呼び出し可能


### PR DESCRIPTION
## Summary
- CIワークフローの `push: branches: [main]` トリガーを削除
- PRベースの開発フローでは、PRでテストが通ってからマージするため不要

## Test plan
- [ ] PRのCIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)