### PR TITLE
fix: AgentCore RuntimeロールにS3読み取り権限を追加

### DIFF
--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -273,6 +273,9 @@ class BakenKaigiApiStack(Stack):
             ],
         )
 
+        # AgentCore Runtime にS3からコードをダウンロードする権限を付与
+        agent_code_asset.grant_read(agentcore_runtime_role)
+
         # AgentCore Runtime (L1 Construct) - CodeConfiguration（direct_code_deploy相当）
         agent_runtime = bedrockagentcore.CfnRuntime(
             self,


### PR DESCRIPTION
## Summary
- AgentCore RuntimeロールにS3からエージェントコードをダウンロードする権限を追加

## Test plan
- [x] CDKテストがすべてパス（34件）
- [ ] CDKデプロイ後、AI相談機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)