### PR TITLE
feat: エージェントLLMをClaude Haiku 4.5に変更

### DIFF
--- a/backend/agentcore/agent.py
+++ b/backend/agentcore/agent.py
@@ -52,7 +52,7 @@ def _get_agent():
         from tools.risk_analysis import analyze_risk_factors
 
         bedrock_model = BedrockModel(
-            model_id=os.environ.get("BEDROCK_MODEL_ID", "jp.amazon.nova-2-lite-v1:0"),
+            model_id=os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-v1"),
             temperature=0.3,
         )
         logger.info(f"BedrockModel created with model_id: {bedrock_model.config.get('model_id')}")


### PR DESCRIPTION
## Summary
- エージェントのデフォルトLLMを `jp.amazon.nova-2-lite-v1:0` から `anthropic.claude-haiku-4-5-v1` に変更
- 日本語での分析要約品質を改善（ツール結果の深い読み解きと洞察生成）
- コスト: ¥1.7 → ¥4.1/リクエスト（約2.4倍、月1,000リクエストで¥4,100）

## Test plan
- [x] AgentCore全278テストパス
- [ ] デプロイ後に実レースデータで分析品質を比較確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)