### PR TITLE
fix: Auth UserPool not configured エラーを解消

### DIFF
--- a/frontend/src/config/amplify.ts
+++ b/frontend/src/config/amplify.ts
@@ -1,5 +1,7 @@
 import { Amplify } from 'aws-amplify';
 
+export let isAuthConfigured = false;
+
 export function configureAmplify() {
   const userPoolId = import.meta.env.VITE_COGNITO_USER_POOL_ID || '';
   const userPoolClientId = import.meta.env.VITE_COGNITO_CLIENT_ID || '';
@@ -30,4 +32,5 @@ export function configureAmplify() {
   };
 
   Amplify.configure(cognitoConfig);
+  isAuthConfigured = true;
 }

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -13,6 +13,10 @@ const mockUpdatePassword = vi.fn()
 const mockDeleteUser = vi.fn()
 const mockSignInWithRedirect = vi.fn()
 
+vi.mock('../config/amplify', () => ({
+  isAuthConfigured: true,
+}))
+
 vi.mock('aws-amplify/auth', () => ({
   getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
   fetchAuthSession: (...args: unknown[]) => mockFetchAuthSession(...args),

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -12,6 +12,7 @@ import {
   deleteUser as amplifyDeleteUser,
   signInWithRedirect,
 } from 'aws-amplify/auth';
+import { isAuthConfigured } from '../config/amplify';
 
 interface AuthUser {
   userId: string;
@@ -46,6 +47,10 @@ export const useAuthStore = create<AuthState>()((set) => ({
   error: null,
 
   checkAuth: async () => {
+    if (!isAuthConfigured) {
+      set({ user: null, isAuthenticated: false, isLoading: false });
+      return;
+    }
     try {
       set({ isLoading: true, error: null });
       const currentUser = await getCurrentUser();


### PR DESCRIPTION
## Summary
- Cognito環境変数（VITE_COGNITO_USER_POOL_ID等）未設定時に `Auth UserPool not configured.` エラーが発生する問題を修正
- `amplify.ts` に `isAuthConfigured` フラグを追加し、`authStore.ts` の `checkAuth()` で未設定時はAmplify API呼び出しをスキップ
- 未設定時は未認証状態（`isAuthenticated: false`）として正常動作

## Test plan
- [ ] `cd frontend && npm run lint` - エラーなし
- [ ] `cd frontend && npm test` - 全テストパス
- [ ] Cognito環境変数未設定でアプリがエラーなく起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)