### PR TITLE
feat: Cognito に Google Identity Provider を追加

### DIFF
--- a/cdk/tests/test_api_stack.py
+++ b/cdk/tests/test_api_stack.py
@@ -391,6 +391,29 @@ class TestApiStack:
 # agentcore CLIでデプロイしたAgentを使用するように変更。
 
 
+class TestCognitoGoogleProvider:
+    """Cognito Google Identity Provider のテスト."""
+
+    def test_google_identity_provider_created(self, template):
+        """Google Identity Providerが作成されること."""
+        template.has_resource_properties(
+            "AWS::Cognito::UserPoolIdentityProvider",
+            {
+                "ProviderName": "Google",
+                "ProviderType": "Google",
+            },
+        )
+
+    def test_user_pool_client_supports_google(self, template):
+        """User Pool ClientがGoogleプロバイダーをサポートすること."""
+        template.has_resource_properties(
+            "AWS::Cognito::UserPoolClient",
+            {
+                "SupportedIdentityProviders": ["COGNITO", "Google"],
+            },
+        )
+
+
 class TestCorsConfiguration:
     """CORS設定のテスト."""
 


### PR DESCRIPTION
## Summary
- Cognito User Pool に Google Identity Provider を追加
- User Pool Client の `supported_identity_providers` に `GOOGLE` を追加
- attribute_mapping で email / fullname をマッピング
- Client → Provider の依存関係を設定（デプロイ順序保証）

## 背景
`/login` で「Googleでログイン」を押すと「Auth UserPool not configured」エラーが発生していた。
CDK 側に Google Identity Provider が未設定だったことが根本原因。

## Test plan
- [ ] CDK デプロイが成功すること
- [ ] `/login` で「Googleでログイン」が動作すること
- [ ] Google OAuth 認証フロー完了後、コールバックでユーザー情報が取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)