### PR TITLE
fix: Cognito OAuth redirect_mismatch エラーを修正

### DIFF
--- a/frontend/src/config/amplify.ts
+++ b/frontend/src/config/amplify.ts
@@ -22,7 +22,7 @@ export function configureAmplify() {
           oauth: {
             domain: import.meta.env.VITE_COGNITO_DOMAIN || '',
             scopes: ['openid', 'email', 'profile'],
-            redirectSignIn: [window.location.origin],
+            redirectSignIn: [`${window.location.origin}/auth/callback`],
             redirectSignOut: [window.location.origin],
             responseType: 'code' as const,
           },


### PR DESCRIPTION
## Summary
- Cognito Hosted UIで `redirect_mismatch` エラーが発生していた問題を修正
- フロントエンドの Amplify 設定で `redirectSignIn` に `/auth/callback` パスが不足していた
- Cognito User Pool Client に登録されている `https://bakenkaigi.com/auth/callback` と一致するよう修正

## Root Cause
| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| Cognito CallbackURL | `https://bakenkaigi.com/auth/callback` | （変更なし） |
| Amplify redirectSignIn | `window.location.origin` (`https://bakenkaigi.com`) | `${window.location.origin}/auth/callback` |

## Test plan
- [ ] Cognito Hosted UIでGoogle認証フローが正常に完了すること
- [ ] `/auth/callback` にリダイレクトされ `AuthCallbackPage` が表示されること
- [ ] ログアウト後のリダイレクトが正常に動作すること
- [ ] ローカル開発環境でも認証フローが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)