### PR TITLE
fix: 無料競馬AIスクレイパーを実際のHTML構造に合わせて修正

### DIFF
--- a/backend/tests/batch/test_muryou_keiba_ai_scraper.py
+++ b/backend/tests/batch/test_muryou_keiba_ai_scraper.py
@@ -583,7 +583,7 @@ class TestScrapeRaces:
         JST = timezone(timedelta(hours=9))
         fixed_now = datetime(2026, 2, 7, 21, 0, 0, tzinfo=JST)
         mock_dt.now.return_value = fixed_now
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_dt.side_effect = datetime
 
         mock_table = MagicMock()
         mock_get_table.return_value = mock_table
@@ -653,7 +653,7 @@ class TestScrapeRaces:
         JST = timezone(timedelta(hours=9))
         fixed_now = datetime(2026, 2, 7, 21, 0, 0, tzinfo=JST)
         mock_dt.now.return_value = fixed_now
-        mock_dt.side_effect = lambda *args, **kw: datetime(*args, **kw)
+        mock_dt.side_effect = datetime
 
         mock_get_table.return_value = MagicMock()
 


### PR DESCRIPTION
## Summary

- 実サイトのHTML構造がスクレイパーの想定と異なり、データが一切取得できない状態を修正
- CSSクラスの要素位置、スコアのspan分離、URL日付≠レース日の3つの問題を解消
- DynamoDB保存時のfloat→Decimal変換を追加
- 統合テストの日付依存をモックで解消

## 修正内容

| 問題 | 修正 |
|------|------|
| クラスが`<td>`ではなく`<p>`にある | タグ非限定の`class_=`検索に変更 |
| スコアが`<span class="mark">◎</span><span class="predict">65.7</span>`に分離 | `span.predict`を優先取得 |
| URLの日付が公開日でレース日と異なる | リンクテキストの「M月D日」で判定 |
| DynamoDBがfloat非対応 | `_convert_floats()`でDecimal変換 |

## Test plan

- [x] 全30テストパス
- [x] 実サイトから2/8の36レースを正常取得確認
- [x] DynamoDB書き込み・読み戻し成功確認（京都1R 16頭分）

🤖 Generated with [Claude Code](https://claude.com/claude-code)