### PR TITLE
fix: OAuth用アクセストークンにCOGNITO_ADMINスコープを追加

### DIFF
--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -181,6 +181,7 @@ class BakenKaigiApiStack(Stack):
                     cognito.OAuthScope.OPENID,
                     cognito.OAuthScope.EMAIL,
                     cognito.OAuthScope.PROFILE,
+                    cognito.OAuthScope.COGNITO_ADMIN,
                 ],
                 callback_urls=[
                     "https://bakenkaigi.com/auth/callback",

--- a/frontend/src/config/amplify.ts
+++ b/frontend/src/config/amplify.ts
@@ -21,7 +21,7 @@ export function configureAmplify() {
         loginWith: {
           oauth: {
             domain: import.meta.env.VITE_COGNITO_DOMAIN || '',
-            scopes: ['openid', 'email', 'profile'],
+            scopes: ['openid', 'email', 'profile', 'aws.cognito.signin.user.admin'],
             redirectSignIn: [`${window.location.origin}/auth/callback`],
             redirectSignOut: [window.location.origin],
             responseType: 'code' as const,


### PR DESCRIPTION
## Summary
- Google OAuth初回ログイン時に `updateUserAttributes` で `custom:display_name` を設定する際、access tokenに `aws.cognito.signin.user.admin` スコープが不足しており「Access Token does not have required scopes」エラーが発生していた
- フロントエンドのAmplify OAuth設定とCDKのCognitoクライアント設定の両方にスコープを追加

## Test plan
- [ ] Google OAuth初回ログインで年齢確認→利用規約→プロフィール設定の順に遷移する
- [ ] プロフィール設定で表示名を入力・設定完了できる（エラーなし）
- [ ] 設定完了後ホームページにリダイレクトされる
- [ ] 既存ユーザーのログインが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)