### PR TITLE
fix: ギャンブル依存症相談窓口のリンクURL修正

### DIFF
--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -11,13 +11,13 @@ describe('Layout', () => {
       expect(helpLink).toBeInTheDocument()
     })
 
-    it('リンクが厚生労働省のページに設定されている', () => {
+    it('リンクがギャンブル等依存症対策推進関係者会議のページに設定されている', () => {
       render(<Layout />)
 
       const helpLink = screen.getByRole('link', { name: /ギャンブル依存症の相談窓口へ/i })
       expect(helpLink).toHaveAttribute(
         'href',
-        'https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000070789.html'
+        'https://www.gaprsc.or.jp/index.html'
       )
     })
 

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,7 +8,7 @@ function HelpLink() {
   return (
     <div className="help-link-section">
       <a
-        href="https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000070789.html"
+        href="https://www.gaprsc.or.jp/index.html"
         target="_blank"
         rel="noopener noreferrer"
         aria-label="ギャンブル依存症の相談窓口へ（新しいタブで開く）"

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -86,7 +86,7 @@ export function SettingsPage() {
         <SettingsMenuItem label="Cookie設定" onClick={() => resetConsent()} />
       </div>
 
-      <a href="https://www.ncgmkohnodai.go.jp/subject/094/gambling.html" target="_blank" rel="noopener noreferrer"
+      <a href="https://www.gaprsc.or.jp/index.html" target="_blank" rel="noopener noreferrer"
         style={{ display: 'block', textAlign: 'center', padding: 20, color: '#c62828', fontSize: 14, textDecoration: 'none' }}>
         ギャンブル依存症相談窓口
       </a>


### PR DESCRIPTION
## Summary
- ギャンブル依存症相談窓口のリンクURLを正しいURL（https://www.gaprsc.or.jp/index.html）に修正
- Layout.tsx、SettingsPage.tsx、Layout.test.tsx の3ファイルを更新

## Test plan
- [x] Layout.test.tsx の4テストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)