### PR TITLE
fix: AgentCoreRuntimeRoleのdescription日本語エラー修正

### DIFF
--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -379,7 +379,7 @@ class BakenKaigiApiStack(Stack):
             "AgentCoreRuntimeRole",
             role_name="baken-kaigi-agentcore-runtime-role",
             assumed_by=iam.ServicePrincipal("bedrock-agentcore.amazonaws.com"),
-            description="AgentCore Runtime用のIAMロール",
+            description="IAM role for AgentCore Runtime",
         )
 
         # DynamoDB 読み取り権限


### PR DESCRIPTION
## Summary
- IAM Roleの`description`に日本語（`AgentCore Runtime用のIAMロール`）を使用していたため、IAMのバリデーション（`[\u0009\u000A\u000D\u0020-\u007E\u00A1-\u00FF]*`パターン）に違反し、CloudFormationスタック更新が繰り返し失敗していた
- 英語に変更: `IAM role for AgentCore Runtime`

## Test plan
- [x] `cdk synth` 成功確認
- [ ] `cdk deploy` でスタック更新が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)