### PR TITLE
fix: 購入ハンドラーのlogger.errorをlogger.exceptionに変更

### DIFF
--- a/backend/src/api/handlers/purchase.py
+++ b/backend/src/api/handlers/purchase.py
@@ -81,7 +81,7 @@ def submit_purchase_handler(event: dict, context: Any) -> dict:
     except IpatSubmissionError as e:
         return internal_error_response(str(e), event=event)
     except IpatGatewayError as e:
-        logger.error("IpatGatewayError: %s", e)
+        logger.exception("IpatGatewayError: %s", e)
         return internal_error_response("IPAT通信エラーが発生しました", event=event)
 
     return success_response(


### PR DESCRIPTION
## Summary
- `purchase.py`の`IpatGatewayError`キャッチ時の`logger.error`を`logger.exception`に変更
- スタックトレース情報がログに記録されるようになり、運用時のデバッグが容易に
- `ipat_balance.py`（PR #302）と同じ修正パターン

## Test plan
- [x] 既存テスト11件すべてパス
- [x] `test_IpatGatewayError発生時に500`、`test_投票送信時IpatGatewayError発生で500` が正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)