### PR TITLE
fix: AgentCore RuntimeのBedrockモデルIDを修正

### DIFF
--- a/backend/agentcore/agent.py
+++ b/backend/agentcore/agent.py
@@ -56,7 +56,7 @@ def _get_agent():
         from tools.speed_index import get_speed_index, list_speed_indices_for_date
 
         bedrock_model = BedrockModel(
-            model_id=os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-v1"),
+            model_id=os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-20251001-v1:0"),
             temperature=0.3,
         )
         logger.info(f"BedrockModel created with model_id: {bedrock_model.config.get('model_id')}")


### PR DESCRIPTION
## Summary
- AgentCore Runtimeが起動時に `ValidationException: The provided model identifier is invalid` で失敗していた
- デフォルトモデルID `anthropic.claude-haiku-4-5-v1` が東京リージョン(ap-northeast-1)で無効だったため、正しいID `anthropic.claude-haiku-4-5-20251001-v1:0` に修正

## Test plan
- [x] AgentCoreテスト全573件パス
- [ ] デプロイ後、`agentcore status` でActiveを確認
- [ ] 本番環境で馬券会議AI相談が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)