### PR TITLE
fix: APIハンドラのfloat金額バリデーション

### DIFF
--- a/backend/src/api/handlers/betting_record.py
+++ b/backend/src/api/handlers/betting_record.py
@@ -1,4 +1,5 @@
 """投票記録APIハンドラー."""
+import math
 from typing import Any
 
 from src.api.auth import AuthenticationError, require_authenticated_user_id
@@ -76,12 +77,16 @@ def create_betting_record_handler(event: dict, context: Any) -> dict:
         return bad_request_response("horse_numbers is required", event=event)
     if amount is None:
         return bad_request_response("amount is required", event=event)
-    if not isinstance(amount, (int, float)) or amount <= 0:
+    if isinstance(amount, bool) or not isinstance(amount, (int, float)):
         return bad_request_response("amount must be a positive number", event=event)
     if isinstance(amount, float):
+        if not math.isfinite(amount):
+            return bad_request_response("amount must be a finite number", event=event)
         if amount != int(amount):
             return bad_request_response("amount must be a whole number", event=event)
         amount = int(amount)
+    if amount <= 0:
+        return bad_request_response("amount must be a positive number", event=event)
 
     use_case = CreateBettingRecordUseCase(
         betting_record_repository=Dependencies.get_betting_record_repository(),
@@ -222,12 +227,16 @@ def settle_betting_record_handler(event: dict, context: Any) -> dict:
     payout = body.get("payout")
     if payout is None:
         return bad_request_response("payout is required", event=event)
-    if not isinstance(payout, (int, float)) or payout < 0:
+    if isinstance(payout, bool) or not isinstance(payout, (int, float)):
         return bad_request_response("payout must be a non-negative number", event=event)
     if isinstance(payout, float):
+        if not math.isfinite(payout):
+            return bad_request_response("payout must be a finite number", event=event)
         if payout != int(payout):
             return bad_request_response("payout must be a whole number", event=event)
         payout = int(payout)
+    if payout < 0:
+        return bad_request_response("payout must be a non-negative number", event=event)
 
     use_case = SettleBettingRecordUseCase(
         betting_record_repository=Dependencies.get_betting_record_repository(),


### PR DESCRIPTION
## Summary
- APIハンドラで`amount`/`payout`がfloat型で送信された場合のバリデーション追加
- 整数値のfloat（`100.0`）→ intに変換して正常処理
- 小数を含むfloat（`100.5`）→ 400エラーを返却
- Money値オブジェクトはint型を期待しているため、floatが混入すると計算結果が不正になるバグを修正

## Test plan
- [x] floatのamount（100.0）→ intに変換されて201
- [x] 小数のamount（100.5）→ 400エラー
- [x] floatのpayout（500.0）→ intに変換されて200
- [x] 小数のpayout（500.5）→ 400エラー
- [x] 既存テスト31件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)