### PR TITLE
fix: BedrockモデルIDをinference profileに変更

### DIFF
--- a/backend/agentcore/agent.py
+++ b/backend/agentcore/agent.py
@@ -56,7 +56,7 @@ def _get_agent():
         from tools.speed_index import get_speed_index, list_speed_indices_for_date
 
         bedrock_model = BedrockModel(
-            model_id=os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-20251001-v1:0"),
+            model_id=os.environ.get("BEDROCK_MODEL_ID", "jp.anthropic.claude-haiku-4-5-20251001-v1:0"),
             temperature=0.3,
         )
         logger.info(f"BedrockModel created with model_id: {bedrock_model.config.get('model_id')}")


### PR DESCRIPTION
## Summary
- Claude Haiku 4.5のon-demand throughput直接呼び出しが東京リージョンで不可になったため、JP inference profile `jp.anthropic.claude-haiku-4-5-20251001-v1:0` を使用するよう変更
- 前回の#309で修正したモデルIDは正しかったが、inference profile経由での呼び出しが必須だった

## Test plan
- [x] AgentCoreテスト全573件パス
- [ ] デプロイ後、AgentCore Runtimeが正常に応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)