### PR TITLE
fix: IPAT設定APIの文字列フィールド型バリデーション

### DIFF
--- a/backend/src/api/handlers/ipat_settings.py
+++ b/backend/src/api/handlers/ipat_settings.py
@@ -40,6 +40,18 @@ def save_ipat_credentials_handler(event: dict, context: Any) -> dict:
             event=event,
         )
 
+    for field_name, field_value in [
+        ("inet_id", inet_id),
+        ("subscriber_number", subscriber_number),
+        ("pin", pin),
+        ("pars_number", pars_number),
+    ]:
+        if not isinstance(field_value, str):
+            return bad_request_response(
+                f"{field_name} must be a string",
+                event=event,
+            )
+
     use_case = SaveIpatCredentialsUseCase(
         credentials_provider=Dependencies.get_credentials_provider(),
     )

--- a/backend/tests/api/handlers/test_ipat_settings.py
+++ b/backend/tests/api/handlers/test_ipat_settings.py
@@ -70,6 +70,50 @@ class TestSaveIpatCredentialsHandler:
         result = save_ipat_credentials_handler(event, None)
         assert result["statusCode"] == 400
 
+    def test_inet_idが整数の場合400(self) -> None:
+        _setup_deps()
+        event = _auth_event(body={
+            "inet_id": 12345678,
+            "subscriber_number": "12345678",
+            "pin": "1234",
+            "pars_number": "5678",
+        })
+        result = save_ipat_credentials_handler(event, None)
+        assert result["statusCode"] == 400
+
+    def test_subscriber_numberが整数の場合400(self) -> None:
+        _setup_deps()
+        event = _auth_event(body={
+            "inet_id": "ABcd1234",
+            "subscriber_number": 12345678,
+            "pin": "1234",
+            "pars_number": "5678",
+        })
+        result = save_ipat_credentials_handler(event, None)
+        assert result["statusCode"] == 400
+
+    def test_pinがリストの場合400(self) -> None:
+        _setup_deps()
+        event = _auth_event(body={
+            "inet_id": "ABcd1234",
+            "subscriber_number": "12345678",
+            "pin": [1, 2, 3, 4],
+            "pars_number": "5678",
+        })
+        result = save_ipat_credentials_handler(event, None)
+        assert result["statusCode"] == 400
+
+    def test_pars_numberがboolの場合400(self) -> None:
+        _setup_deps()
+        event = _auth_event(body={
+            "inet_id": "ABcd1234",
+            "subscriber_number": "12345678",
+            "pin": "1234",
+            "pars_number": True,
+        })
+        result = save_ipat_credentials_handler(event, None)
+        assert result["statusCode"] == 400
+
 
 class TestGetIpatStatusHandler:
     """get_ipat_status_handler のテスト."""


### PR DESCRIPTION
## Summary
- IPAT設定保存APIで`inet_id`, `subscriber_number`, `pin`, `pars_number`に型バリデーションを追加
- 非文字列値（整数、リスト、bool等）が送信されると`IpatCredentials`の正規表現matchで`TypeError`が発生していた
- ハンドラーで`isinstance(value, str)`チェックを追加し、適切に400を返すようにした

## Test plan
- [x] 既存9テスト全パス
- [x] 新規4テスト追加（整数/リスト/bool型の検出）
- [x] 全バックエンドテスト1719件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)