### PR TITLE
fix: モーダル/BottomSheetのoverflow競合修正

### DIFF
--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -19,12 +19,19 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
   useEffect(() => {
     if (isOpen) {
       acquireScrollLock();
-      document.addEventListener('keydown', handleKeyDown);
     }
     return () => {
       if (isOpen) {
         releaseScrollLock();
       }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen, handleKeyDown]);

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -35,12 +35,19 @@ export function ConfirmModal({
   useEffect(() => {
     if (isOpen) {
       acquireScrollLock();
-      document.addEventListener('keydown', handleKeyDown);
     }
     return () => {
       if (isOpen) {
         releaseScrollLock();
       }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen, handleKeyDown]);

--- a/frontend/src/utils/scrollLock.test.ts
+++ b/frontend/src/utils/scrollLock.test.ts
@@ -1,61 +1,52 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { acquireScrollLock, releaseScrollLock, _resetForTest } from './scrollLock';
 
-// テストごとにモジュールをリセットするため動的importを使用
 describe('scrollLock', () => {
   beforeEach(() => {
+    _resetForTest();
     document.body.style.overflow = '';
   });
 
-  it('acquireScrollLock sets overflow to hidden', async () => {
-    // 毎回新しいモジュールインスタンスを取得
-    const mod = await import('./scrollLock');
-    // lockCount をリセットするため、release を十分回数呼ぶ
-    for (let i = 0; i < 10; i++) mod.releaseScrollLock();
-    document.body.style.overflow = '';
-
-    mod.acquireScrollLock();
+  it('acquireScrollLock sets overflow to hidden', () => {
+    acquireScrollLock();
     expect(document.body.style.overflow).toBe('hidden');
-    // cleanup
-    mod.releaseScrollLock();
+    releaseScrollLock();
   });
 
-  it('releaseScrollLock restores overflow when count reaches 0', async () => {
-    const mod = await import('./scrollLock');
-    for (let i = 0; i < 10; i++) mod.releaseScrollLock();
-    document.body.style.overflow = '';
-
-    mod.acquireScrollLock();
-    mod.releaseScrollLock();
+  it('releaseScrollLock restores overflow when count reaches 0', () => {
+    acquireScrollLock();
+    releaseScrollLock();
     expect(document.body.style.overflow).toBe('');
   });
 
-  it('multiple acquires keep overflow hidden until all released', async () => {
-    const mod = await import('./scrollLock');
-    for (let i = 0; i < 10; i++) mod.releaseScrollLock();
-    document.body.style.overflow = '';
-
-    mod.acquireScrollLock();
-    mod.acquireScrollLock();
+  it('multiple acquires keep overflow hidden until all released', () => {
+    acquireScrollLock();
+    acquireScrollLock();
     expect(document.body.style.overflow).toBe('hidden');
 
-    mod.releaseScrollLock();
+    releaseScrollLock();
     expect(document.body.style.overflow).toBe('hidden');
 
-    mod.releaseScrollLock();
+    releaseScrollLock();
     expect(document.body.style.overflow).toBe('');
   });
 
-  it('releaseScrollLock does not go below 0', async () => {
-    const mod = await import('./scrollLock');
-    for (let i = 0; i < 10; i++) mod.releaseScrollLock();
-    document.body.style.overflow = '';
-
-    mod.releaseScrollLock();
-    mod.releaseScrollLock();
+  it('releaseScrollLock does not go below 0', () => {
+    releaseScrollLock();
+    releaseScrollLock();
     expect(document.body.style.overflow).toBe('');
 
-    mod.acquireScrollLock();
+    acquireScrollLock();
     expect(document.body.style.overflow).toBe('hidden');
-    mod.releaseScrollLock();
+    releaseScrollLock();
+  });
+
+  it('restores original overflow value', () => {
+    document.body.style.overflow = 'auto';
+    acquireScrollLock();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    releaseScrollLock();
+    expect(document.body.style.overflow).toBe('auto');
   });
 });

--- a/frontend/src/utils/scrollLock.ts
+++ b/frontend/src/utils/scrollLock.ts
@@ -5,17 +5,25 @@
  * すべてが閉じるまで overflow: hidden を維持する。
  */
 let lockCount = 0;
+let savedOverflow = '';
 
 export function acquireScrollLock(): void {
-  lockCount++;
-  if (lockCount === 1) {
+  if (lockCount === 0) {
+    savedOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
   }
+  lockCount++;
 }
 
 export function releaseScrollLock(): void {
   lockCount = Math.max(0, lockCount - 1);
   if (lockCount === 0) {
-    document.body.style.overflow = '';
+    document.body.style.overflow = savedOverflow;
   }
+}
+
+/** テスト用: 内部状態をリセットする */
+export function _resetForTest(): void {
+  lockCount = 0;
+  savedOverflow = '';
 }


### PR DESCRIPTION
## Summary
- 複数のモーダル/BottomSheetが同時に開いている場合、1つを閉じると他がまだ開いているのに`body overflow`がリセットされてスクロール可能になるバグを修正
- 参照カウント方式の`scrollLock`ユーティリティを導入し、全オーバーレイが閉じるまで`overflow: hidden`を維持
- `ConfirmModal`と`BottomSheet`の両方を修正

## Test plan
- [x] scrollLockユーティリティの単体テスト4件パス
- [x] TypeScriptビルドエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)