### PR TITLE
fix: loss_limitのbool型チェック漏れとcart bet_type型チェック追加

### DIFF
--- a/backend/src/api/handlers/cart.py
+++ b/backend/src/api/handlers/cart.py
@@ -59,11 +59,13 @@ def add_to_cart(event: dict, context: Any) -> dict:
     # パラメータ変換
     cart_id = CartId(body["cart_id"]) if body.get("cart_id") else None
 
+    if not isinstance(body["bet_type"], str):
+        return bad_request_response("bet_type must be a string", event=event)
     try:
         # 大文字・小文字両方を受け付ける
         bet_type_str = body["bet_type"].lower()
         bet_type = BetType(bet_type_str)
-    except (ValueError, AttributeError):
+    except ValueError:
         return bad_request_response(f"Invalid bet_type: {body['bet_type']}", event=event)
 
     if not isinstance(body["horse_numbers"], list):

--- a/backend/src/api/handlers/loss_limit.py
+++ b/backend/src/api/handlers/loss_limit.py
@@ -130,7 +130,7 @@ def set_loss_limit_handler(event: dict, context: Any) -> dict:
         return bad_request_response("amount is required", event=event)
 
     amount = body["amount"]
-    if not isinstance(amount, int):
+    if isinstance(amount, bool) or not isinstance(amount, int):
         return bad_request_response("amount must be an integer", event=event)
 
     user_repo = Dependencies.get_user_repository()
@@ -178,7 +178,7 @@ def update_loss_limit_handler(event: dict, context: Any) -> dict:
         return bad_request_response("amount is required", event=event)
 
     amount = body["amount"]
-    if not isinstance(amount, int):
+    if isinstance(amount, bool) or not isinstance(amount, int):
         return bad_request_response("amount must be an integer", event=event)
 
     user_repo = Dependencies.get_user_repository()

--- a/backend/tests/api/handlers/test_cart.py
+++ b/backend/tests/api/handlers/test_cart.py
@@ -363,6 +363,22 @@ class TestAddToCartTypeValidation:
         response = add_to_cart(event, None)
         assert response["statusCode"] == 400
 
+    def test_bet_typeが整数の場合400(self) -> None:
+        from src.api.handlers.cart import add_to_cart
+
+        Dependencies.set_cart_repository(MockCartRepository())
+        event = {
+            "body": json.dumps({
+                "race_id": "2024060111",
+                "race_name": "日本ダービー",
+                "bet_type": 123,
+                "horse_numbers": [1],
+                "amount": 100,
+            }),
+        }
+        response = add_to_cart(event, None)
+        assert response["statusCode"] == 400
+
     def test_horse_numbersが文字列の場合400(self) -> None:
         from src.api.handlers.cart import add_to_cart
 

--- a/backend/tests/api/handlers/test_loss_limit.py
+++ b/backend/tests/api/handlers/test_loss_limit.py
@@ -149,6 +149,13 @@ class TestSetLossLimit:
         resp = set_loss_limit_handler(event, None)
         assert resp["statusCode"] == 400
 
+    def test_amountがboolで400(self):
+        event = _make_event(sub="user-123", body={"amount": True})
+        resp = set_loss_limit_handler(event, None)
+        assert resp["statusCode"] == 400
+        body = json.loads(resp["body"])
+        assert "integer" in body["error"]["message"].lower()
+
     def test_既に設定済みで400(self):
         repo = Dependencies.get_user_repository()
         repo.save(_make_user(loss_limit=Money.of(50000)))
@@ -192,6 +199,13 @@ class TestUpdateLossLimit:
         event = _make_event(sub="user-123", body={})
         resp = update_loss_limit_handler(event, None)
         assert resp["statusCode"] == 400
+
+    def test_amountがboolで400(self):
+        event = _make_event(sub="user-123", body={"amount": False})
+        resp = update_loss_limit_handler(event, None)
+        assert resp["statusCode"] == 400
+        body = json.loads(resp["body"])
+        assert "integer" in body["error"]["message"].lower()
 
     def test_限度額未設定で400(self):
         repo = Dependencies.get_user_repository()


### PR DESCRIPTION
## Summary
- `loss_limit.py`: set/updateハンドラーでbool型を弾くチェック追加（Pythonのboolはintのサブクラスのため `isinstance(True, int)` がTrueになる）
- `cart.py`: bet_typeに明示的な文字列型チェック追加（AttributeError catchに依存する暗黙バリデーションを明示化）

## Test plan
- [x] set_loss_limitでamount=True送信時に400エラー+適切なメッセージ返却を確認
- [x] update_loss_limitでamount=False送信時に400エラー+適切なメッセージ返却を確認
- [x] add_to_cartでbet_type=123(整数)送信時に400エラー返却を確認
- [x] 全1753テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)