### PR TITLE
fix: Lambda環境変数にALLOW_DEV_ORIGINSが設定されないCORSバグを修正

### DIFF
--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -1564,10 +1564,10 @@ class BakenKaigiApiStack(Stack):
             runtime=lambda_.Runtime.PYTHON_3_12,
             layers=[deps_layer],
             environment={
+                **lambda_environment,
                 "PYTHONPATH": "/var/task:/opt/python",
                 # agentcore CLIでデプロイしたAgentを参照
                 "AGENTCORE_AGENT_ARN": agentcore_agent_arn,
-                **({"ALLOW_DEV_ORIGINS": "true"} if allow_dev_origins else {}),
             },
         )
 

--- a/cdk/tests/test_api_stack.py
+++ b/cdk/tests/test_api_stack.py
@@ -437,30 +437,31 @@ class TestCorsConfiguration:
         )
 
     def test_lambda_env_has_allow_dev_origins_when_enabled(self, template_with_dev_origins):
-        """allow_dev_origins=Trueの場合、Lambda環境変数にALLOW_DEV_ORIGINSが含まれること."""
-        from aws_cdk import assertions
-
-        template_with_dev_origins.has_resource_properties(
-            "AWS::Lambda::Function",
-            assertions.Match.object_like({
-                "Environment": {
-                    "Variables": assertions.Match.object_like({
-                        "ALLOW_DEV_ORIGINS": "true",
-                    }),
-                },
-            }),
-        )
+        """allow_dev_origins=Trueの場合、すべてのLambda関数の環境変数にALLOW_DEV_ORIGINSが含まれること."""
+        resources = template_with_dev_origins.find_resources("AWS::Lambda::Function")
+        for logical_id, resource in resources.items():
+            env_vars = (
+                resource.get("Properties", {})
+                .get("Environment", {})
+                .get("Variables", {})
+            )
+            assert env_vars.get("ALLOW_DEV_ORIGINS") == "true", (
+                f"{logical_id} should have ALLOW_DEV_ORIGINS=true"
+            )
 
     def test_lambda_env_no_allow_dev_origins_by_default(self, template_without_dev_origins):
         """デフォルトではLambda環境変数にALLOW_DEV_ORIGINSが含まれないこと."""
-        from aws_cdk import assertions
-
-        # いずれかのLambdaにALLOW_DEV_ORIGINSが設定されていないことを確認
+        # すべてのLambda関数の環境変数にALLOW_DEV_ORIGINSが設定されていないことを確認
         resources = template_without_dev_origins.find_resources("AWS::Lambda::Function")
-        for _logical_id, resource in resources.items():
-            env_vars = resource.get("Properties", {}).get("Environment", {}).get("Variables", {})
-            assert "ALLOW_DEV_ORIGINS" not in env_vars, \
-                f"ALLOW_DEV_ORIGINS should not be set when allow_dev_origins=False"
+        for logical_id, resource in resources.items():
+            env_vars = (
+                resource.get("Properties", {})
+                .get("Environment", {})
+                .get("Variables", {})
+            )
+            assert "ALLOW_DEV_ORIGINS" not in env_vars, (
+                f"{logical_id}: ALLOW_DEV_ORIGINS should not be set when allow_dev_origins=False"
+            )
 
     def test_cors_denies_dev_origins_by_default(self, template_without_dev_origins):
         """デフォルトで開発用オリジンは許可されないこと."""


### PR DESCRIPTION
## Summary
- `allow_dev_origins=true` でデプロイ時、API GatewayのCORSプリフライトにはlocalhostが許可されるが、Lambda環境変数 `ALLOW_DEV_ORIGINS` が未設定のため、レスポンスヘッダーのCORSオリジンにlocalhostが含まれずCORSエラーとなる問題を修正
- 共通 `lambda_environment` と `agentcore_consultation_fn` の両方に環境変数を追加

## Test plan
- [x] CDKテスト追加: `allow_dev_origins=True` 時にLambda環境変数に `ALLOW_DEV_ORIGINS` が含まれること
- [x] CDKテスト追加: `allow_dev_origins=False` 時にLambda環境変数に `ALLOW_DEV_ORIGINS` が含まれないこと
- [x] 全56件のCDKテスト通過
- [x] `cdk synth --context jravan=true` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)