### PR TITLE
fix: 資金配分の全馬オッズ0時にZeroDivisionErrorを修正

### DIFF
--- a/backend/agentcore/tools/bet_analysis.py
+++ b/backend/agentcore/tools/bet_analysis.py
@@ -902,6 +902,10 @@ def _optimize_fund_allocation(
         })
         total_kelly += kelly_fraction
 
+    # 有効なオッズの馬がなかった場合は早期リターン
+    if not allocations:
+        return {"allocations": [], "strategy": "有効なオッズデータがないため配分不可"}
+
     # ケリー比率に基づいて配分
     if total_kelly > 0:
         for alloc in allocations:


### PR DESCRIPTION
## Summary
- `_optimize_fund_allocation` で全馬のオッズが0以下の場合、`allocations` リストが空になり `len(allocations)` でゼロ除算（`ZeroDivisionError`）が発生する不具合を修正
- 空リストの場合に早期リターンするガードを追加

## Test plan
- [x] 全馬オッズ0のケースでZeroDivisionErrorが発生しないことを確認
- [x] 全馬オッズNoneのケースも同様に安全に処理されることを確認  
- [x] 一部の馬のオッズが0でも残りの馬で正常に配分されることを確認
- [x] 既存テスト1782件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)