### PR TITLE
fix: 買い目提案JSONレスポンスの構造検証を追加しTypeErrorを防止

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -466,11 +466,19 @@ class ApiClient {
     }
     jsonStr = jsonStr.substring(firstBrace, lastBrace + 1);
     try {
-      const data = JSON.parse(jsonStr);
-      if (!Array.isArray(data.proposed_bets)) {
-        return { success: false, error: data.error || '提案データの形式が不正です' };
+      const parsed: unknown = JSON.parse(jsonStr);
+      if (typeof parsed !== 'object' || parsed === null) {
+        return { success: false, error: '提案データの形式が不正です' };
       }
-      return { success: true, data: data as BetProposalResponse };
+      const data = parsed as { proposed_bets?: unknown; error?: unknown };
+      if (!Array.isArray(data.proposed_bets)) {
+        const errorMessage =
+          typeof data.error === 'string' && data.error.trim().length > 0
+            ? data.error
+            : '提案データの形式が不正です';
+        return { success: false, error: errorMessage };
+      }
+      return { success: true, data: parsed as BetProposalResponse };
     } catch {
       return { success: false, error: '提案データの解析に失敗しました' };
     }


### PR DESCRIPTION
## Summary
- AgentCoreがエラーJSONを`---BET_PROPOSALS_JSON---`セパレータ内に返した場合、`proposed_bets`フィールドが存在しないオブジェクトがコンポーネントに渡り、`.map()`呼び出しで`TypeError`が発生する不具合を修正
- `JSON.parse`後に`proposed_bets`が配列であることを検証し、不正な形式の場合はエラーレスポンスとして返すよう変更

## Test plan
- [ ] フロントエンドビルド成功確認（`npm run build`）
- [ ] AI提案生成が正常に動作することを確認
- [ ] AgentCoreツールエラー時にクラッシュせずエラー表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)