### PR TITLE
fix: IPAT残高取得のKeyErrorをIpatGatewayErrorに変換

### DIFF
--- a/backend/src/infrastructure/providers/jravan_ipat_gateway.py
+++ b/backend/src/infrastructure/providers/jravan_ipat_gateway.py
@@ -103,3 +103,7 @@ class JraVanIpatGateway(IpatGateway):
             )
         except requests.RequestException as e:
             raise IpatGatewayError(f"Failed to get balance: {e}") from e
+        except KeyError as e:
+            raise IpatGatewayError(
+                f"Failed to get balance: missing field {e} in response"
+            ) from e


### PR DESCRIPTION
## Summary
- `jravan_ipat_gateway.py` の `get_balance()` でAPIレスポンスにbalanceフィールドが不足した場合、`KeyError` が未処理のまま伝播し、Lambdaハンドラーで適切に処理されず500エラーになるバグを修正
- `except KeyError` を追加して `IpatGatewayError` に変換し、ハンドラーの既存エラーハンドリングで適切なエラーレスポンスを返すようにした

## Test plan
- [x] フィールド全欠損時にIpatGatewayErrorが発生するテスト追加
- [x] 一部フィールド欠損時にIpatGatewayErrorが発生するテスト追加
- [x] 既存テスト全1784件パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)