### PR TITLE
fix: 未知のURLで空白ページが表示される不具合を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { Layout } from './components/layout/Layout';
 import { RacesPage } from './pages/RacesPage';
@@ -71,6 +71,9 @@ function App() {
           <Route path="purchase/confirm" element={<AuthGuard><PurchaseConfirmPage /></AuthGuard>} />
           <Route path="purchase/history" element={<AuthGuard><PurchaseHistoryPage /></AuthGuard>} />
           <Route path="settings/ipat" element={<AuthGuard><IpatSettingsPage /></AuthGuard>} />
+
+          {/* 存在しないパスはホームにリダイレクト */}
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- 存在しないパス（例: `/nonexistent-page`）にアクセスすると完全に空白のページが表示されていた
- `App.tsx` に catch-all ルート `<Route path="*" />` を追加し、未知のURLはホーム（`/`）にリダイレクトするようにした
- 本番サイト（bakenkaigi.com）での操作中に発見

## Test plan
- [x] `npm run build` でビルド成功を確認
- [ ] デプロイ後、`/nonexistent-page` にアクセスしてホームにリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)