### PR TITLE
fix: IPAT残高取得の未ハンドル例外でCORSヘッダー欠落を修正

### DIFF
--- a/backend/src/api/handlers/ipat_balance.py
+++ b/backend/src/api/handlers/ipat_balance.py
@@ -41,6 +41,9 @@ def get_ipat_balance_handler(event: dict, context: Any) -> dict:
     except IpatGatewayError as e:
         logger.exception("IpatGatewayError: %s", e)
         return internal_error_response("IPAT通信エラーが発生しました", event=event)
+    except Exception as e:
+        logger.exception("Unexpected error in get_ipat_balance: %s", e)
+        return internal_error_response("IPAT残高の取得に失敗しました", event=event)
 
     return success_response({
         "bet_dedicated_balance": balance.bet_dedicated_balance,


### PR DESCRIPTION
## Summary
- IPAT残高取得API (`/ipat/balance`) で予期しない例外（`ClientError`等）が発生した場合、Lambda runtimeがCORSヘッダーなしの500を返していた
- ブラウザ側では `net::ERR_FAILED` として表示され、購入確認ページが「読み込み中...」のまま固まる不具合が発生
- 包括的な `Exception` キャッチを追加し、CORSヘッダー付きの500レスポンスを確実に返すようにした

## Test plan
- [x] 既存テスト5件通過
- [x] 新規テスト追加: `test_予期しない例外でもCORSヘッダー付き500が返る`
- [ ] 本番環境で購入確認ページのIPAT残高取得エラーが日本語で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)