### PR TITLE
fix: 日付切替時にレース場が存在しない場合「レースがありません」と表示される不具合を修正

### DIFF
--- a/frontend/src/pages/RacesPage.tsx
+++ b/frontend/src/pages/RacesPage.tsx
@@ -145,8 +145,7 @@ export function RacesPage() {
   const [datesLoading, setDatesLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // 初回会場選択のためのref（無限ループ防止）
-  const isInitialVenueSet = useRef(false);
+  // 初回日付選択のためのref（無限ループ防止）
   const isInitialDateSet = useRef(false);
 
   // 開催日一覧を取得
@@ -214,15 +213,15 @@ export function RacesPage() {
     if (response.success && response.data) {
       setRaces(response.data.races);
       setVenues(response.data.venues);
-      // 初回または選択中の会場が新しい日付に存在しない場合、最初の会場を選択
-      if (response.data.venues.length > 0) {
+      // 選択中の会場が新しい日付に存在しない場合、最初の会場を選択
+      const fetchedVenues = response.data.venues;
+      if (fetchedVenues.length > 0) {
         setSelectedVenue((prev) => {
-          if (!prev || !response.data!.venues.includes(prev)) {
-            return response.data!.venues[0];
+          if (!prev || !fetchedVenues.includes(prev)) {
+            return fetchedVenues[0];
           }
           return prev;
         });
-        isInitialVenueSet.current = true;
       }
     } else {
       setError(response.error || 'レースの取得に失敗しました');


### PR DESCRIPTION
## Summary
- レース一覧で日付を切り替えた際、前の日付で選択していたレース場が新しい日付に存在しない場合「レースがありません」と表示される不具合を修正
- 例: 2/8(日)東京を選択後、2/9(月)に切替→2/9に東京開催がないため空表示になる
- 日付切替後、selectedVenueが新しい日付のvenueリストに含まれない場合、最初のvenueに自動フォールバック

## Test plan
- [x] TypeScriptビルド成功
- [x] Viteビルド成功
- [ ] 本番環境で2/8東京→2/9切替時に京都のレースが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)