### PR TITLE
fix: レース詳細ページのAPIエラーメッセージ日本語化

### DIFF
--- a/frontend/src/pages/RaceDetailPage.test.tsx
+++ b/frontend/src/pages/RaceDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '../test/utils'
 import { RaceDetailPage } from './RaceDetailPage'
 import { useCartStore } from '../stores/cartStore'
+import { apiClient } from '../api/client'
 
 // react-router-domのuseParamsをモック
 vi.mock('react-router-dom', async () => {
@@ -61,6 +62,40 @@ describe('RaceDetailPage', () => {
 
       const guideText = await screen.findByText(/カートに追加後、AIと一緒に買い目を確認できます/i)
       expect(guideText).toHaveClass('ai-guide-text')
+    })
+  })
+
+  describe('APIエラーメッセージの日本語化', () => {
+    it('英語のAPIエラーメッセージは日本語フォールバックで表示される', async () => {
+      vi.mocked(apiClient.getRaceDetail).mockResolvedValueOnce({
+        success: false,
+        error: 'Race not found',
+      })
+
+      render(<RaceDetailPage />)
+
+      expect(await screen.findByText('レース詳細の取得に失敗しました')).toBeInTheDocument()
+    })
+
+    it('日本語を含むエラーメッセージはそのまま表示される', async () => {
+      vi.mocked(apiClient.getRaceDetail).mockResolvedValueOnce({
+        success: false,
+        error: 'IPAT通信エラーが発生しました',
+      })
+
+      render(<RaceDetailPage />)
+
+      expect(await screen.findByText('IPAT通信エラーが発生しました')).toBeInTheDocument()
+    })
+
+    it('エラーメッセージがない場合はフォールバックが表示される', async () => {
+      vi.mocked(apiClient.getRaceDetail).mockResolvedValueOnce({
+        success: false,
+      })
+
+      render(<RaceDetailPage />)
+
+      expect(await screen.findByText('レース詳細の取得に失敗しました')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/RaceDetailPage.tsx
+++ b/frontend/src/pages/RaceDetailPage.tsx
@@ -5,6 +5,7 @@ import { useCartStore } from '../stores/cartStore';
 import type { RaceDetail, BetType, BetMethod, ColumnSelections } from '../types';
 import { BetTypeLabels, BetTypeRequiredHorses, BetTypeOrdered, getVenueName } from '../types';
 import { apiClient } from '../api/client';
+import { toJapaneseError } from '../stores/purchaseStore';
 import { buildJraShutsubaUrl } from '../utils/jraUrl';
 import { getBetMethodLabel } from '../utils/betMethods';
 import { BetTypeSheet } from '../components/bet/BetTypeSheet';
@@ -58,10 +59,7 @@ export function RaceDetailPage() {
       if (response.success && response.data) {
         setRace(response.data);
       } else {
-        const fallback = 'レース詳細の取得に失敗しました';
-        const err = response.error;
-        // ASCII英語のみのAPIエラーメッセージはフォールバックに変換
-        setError(!err || /^[\x20-\x7E]+$/.test(err) ? fallback : err);
+        setError(toJapaneseError(response.error, 'レース詳細の取得に失敗しました'));
       }
 
       setLoading(false);


### PR DESCRIPTION
## Summary
- 存在しないレースIDにアクセスした際、APIの英語エラー「Race not found」がそのまま表示されていた不具合を修正
- ASCII英語のみのエラーメッセージを日本語フォールバック「レース詳細の取得に失敗しました」に変換

## Test plan
- [x] 既存RaceDetailPageテスト4件パス
- [ ] 本番環境で存在しないレースIDアクセス時に日本語エラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)