### PR TITLE
fix: Secrets Manager VPCエンドポイント追加でIPAT残高取得タイムアウトを修正

### DIFF
--- a/cdk/stacks/jravan_server_stack.py
+++ b/cdk/stacks/jravan_server_stack.py
@@ -70,18 +70,18 @@ class JraVanServerStack(Stack):
                 "DynamoDbEndpoint",
                 service=ec2.GatewayVpcEndpointAwsService.DYNAMODB,
             )
-
-            # Secrets Manager VPC Interface Endpoint
-            # Lambda（ISOLATED サブネット）から Secrets Manager へアクセスするために必要
-            self.vpc.add_interface_endpoint(
-                "SecretsManagerEndpoint",
-                service=ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
-                subnets=ec2.SubnetSelection(
-                    subnet_type=ec2.SubnetType.PRIVATE_ISOLATED,
-                ),
-            )
         else:
             self.vpc = vpc
+
+        # Secrets Manager VPC Interface Endpoint
+        # Lambda（ISOLATED サブネット）から Secrets Manager へアクセスするために必要
+        self.vpc.add_interface_endpoint(
+            "SecretsManagerEndpoint",
+            service=ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+            subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_ISOLATED,
+            ),
+        )
 
         # ========================================
         # セキュリティグループ


### PR DESCRIPTION
## Summary
- ISOLATEDサブネットのLambdaからSecrets Managerへの通信がタイムアウト（30秒）していた問題を修正
- VPC Interface Endpoint（Secrets Manager）をISOLATEDサブネットに追加
- これによりIPAT残高取得・IPAT認証情報保存のAPI呼び出しが正常に動作するようになる

## Root Cause
- LambdaはNAT Gatewayなしの`PRIVATE_ISOLATED`サブネットに配置されている
- DynamoDBにはGateway Endpoint（無料）が設定済みだが、Secrets ManagerにはInterface Endpointが未設定
- `SecretsManagerCredentialsProvider`がboto3でSecrets Manager APIを呼び出す際、インターネットにもVPCエンドポイントにもアクセスできずタイムアウト

## Test plan
- [ ] CDKデプロイが成功すること
- [ ] IPAT残高取得APIが504ではなく正常レスポンスを返すこと
- [ ] 購入確認ページでIPAT残高が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)