### PR TITLE
fix: ギャンブル依存症相談窓口リンクの見切れを修正

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -48,7 +48,7 @@
     --font-size-xl: 18px;
 
     /* レイアウト */
-    --bottom-nav-height: 60px;
+    --bottom-nav-height: 78px;
     --app-max-width: 640px;
 
     /* z-index スケール */
@@ -197,7 +197,7 @@ body {
 /* Main Content */
 main {
     padding: 16px;
-    padding-bottom: 120px; /* help-link + bottom-nav分 */
+    padding-bottom: 140px; /* help-link + bottom-nav分 */
     max-width: var(--app-max-width);
     margin: 0 auto;
 }
@@ -1480,13 +1480,12 @@ main {
 /* 依存症相談窓口リンク */
 .help-link-section {
     position: fixed;
-    bottom: var(--bottom-nav-height);
+    bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px));
     left: 50%;
     transform: translateX(-50%);
     width: 100%;
     max-width: var(--app-max-width);
     padding: var(--space-2) var(--space-4);
-    padding-bottom: calc(var(--space-2) + env(safe-area-inset-bottom, 0px));
     background: var(--color-neutral-50);
     text-align: center;
     border-top: 1px solid var(--color-neutral-200);


### PR DESCRIPTION
## Summary
- `--bottom-nav-height` が実際のボトムナビ高さ(77px)より小さい60pxに設定されていたため、相談窓口リンクがボトムナビの背面に17px隠れて見切れていた
- `--bottom-nav-height` を78pxに修正し、`safe-area-inset-bottom` も考慮してiPhoneでも正しく表示されるようにした

## Changes
- `--bottom-nav-height`: 60px → 78px
- `.help-link-section` の `bottom`: `calc(var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px))`
- `main` の `padding-bottom`: 120px → 140px

## Test plan
- [ ] デスクトップブラウザで「困ったときは｜ギャンブル依存症相談窓口」が見切れずに表示される
- [ ] モバイルブラウザ（iPhone含む）で同テキストが正しく表示される
- [ ] ボトムナビとの重なりがない
- [ ] ページ最下部のコンテンツがボトムナビ・相談窓口リンクに隠れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)