### PR TITLE
fix: AI提案「全てカートに追加」の別レースエラー時サイレント失敗を修正

### DIFF
--- a/frontend/src/components/proposal/BetProposalSheet.tsx
+++ b/frontend/src/components/proposal/BetProposalSheet.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react';
 import { BottomSheet } from '../common/BottomSheet';
 import { ProposalCard } from './ProposalCard';
 import { apiClient } from '../../api/client';
-import { useCartStore } from '../../stores/cartStore';
+import { useCartStore, type AddItemResult } from '../../stores/cartStore';
 import { useAppStore } from '../../stores/appStore';
 import type { RaceDetail, BetProposalResponse } from '../../types';
 import './BetProposalSheet.css';
@@ -126,6 +126,7 @@ export function BetProposalSheet({ isOpen, onClose, race }: BetProposalSheetProp
   const handleAddAll = () => {
     if (!result) return;
     let addedCount = 0;
+    let firstError: AddItemResult | null = null;
     const newIndices = new Set(addedIndices);
 
     result.proposed_bets.forEach((bet, index) => {
@@ -153,12 +154,20 @@ export function BetProposalSheet({ isOpen, onClose, race }: BetProposalSheetProp
       if (addResult === 'ok') {
         addedCount++;
         newIndices.add(index);
+      } else if (!firstError) {
+        firstError = addResult;
       }
     });
 
     if (addedCount > 0) {
       setAddedIndices(newIndices);
       showToast(`${addedCount}件をカートに追加しました`);
+    } else if (firstError) {
+      const message =
+        firstError === 'different_race'
+          ? 'カートには同じレースの買い目のみ追加できます'
+          : '金額が範囲外です';
+      showToast(message, 'error');
     }
   };
 


### PR DESCRIPTION
## Summary
- AI提案ダイアログの「全てカートに追加」ボタンが、カートに別レースの買い目がある場合にエラーメッセージを表示せずサイレントに失敗していたバグを修正
- 個別の「カートに追加」ボタンと同様に `different_race` / `invalid_amount` のエラートーストを表示するように統一

## 再現手順
1. 京都5RなどでAI提案→全てカートに追加
2. 東京11RでAI提案→全てカートに追加
3. **修正前**: 何も起きない（サイレント失敗）
4. **修正後**: 「カートには同じレースの買い目のみ追加できます」のエラートースト表示

## Test plan
- [ ] カートが空の状態で「全てカートに追加」→正常に追加される
- [ ] カートに別レースの買い目がある状態で「全てカートに追加」→エラートースト表示
- [ ] 個別の「カートに追加」ボタンの動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)