### PR TITLE
fix: SSM PowerShellでRead-S3Objectに戻してaws CLI PATH問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,7 +304,14 @@ jobs:
           $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
           $backupDir = "C:\jravan-api\backup-$timestamp"
 
-          # S3からダウンロード（AWS Tools for PowerShellはWindows AMIに標準搭載）
+          # AWS Tools for PowerShellモジュール確認（Windows AMIに標準搭載）
+          if (-not (Get-Module -ListAvailable -Name 'AWS.Tools.S3')) {
+            throw 'AWS.Tools.S3 module not found. Ensure AWS Tools for PowerShell is installed on the EC2 instance.'
+          }
+          Import-Module AWS.Tools.S3
+          Set-DefaultAWSRegion -Region 'ap-northeast-1'
+
+          # S3からダウンロード
           Write-Output "Downloading from s3://$bucketName/$s3Key"
           Read-S3Object -BucketName $bucketName -Key $s3Key -File $tempZip
 


### PR DESCRIPTION
## Summary
- SSMセッション内で`aws s3 cp`が`CommandNotFoundException`になる問題を修正
- `Read-S3Object`（AWS Tools for PowerShell）に戻す。Windows AMIに標準搭載されSSMセッションで確実に利用可能
- #357のエスケープ修正は維持したまま、S3ダウンロード部分のみ変更

## Test plan
- [ ] `workflow_dispatch`でdeploy-ec2ジョブが成功することを確認
- [ ] EC2上のヘルスチェック（/health）が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)