### PR TITLE
fix: JraVanApiスケジュールタスク再起動に修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -351,10 +351,21 @@ jobs:
 
           # スケジュールタスク再起動（JraVanApiはTask Schedulerで管理）
           Write-Output 'Restarting JraVanApi task...'
-          Stop-ScheduledTask -TaskName 'JraVanApi' -ErrorAction SilentlyContinue
+          $task = Get-ScheduledTask -TaskName 'JraVanApi' -ErrorAction SilentlyContinue
+          if (-not $task) {
+            Write-Output 'ERROR: Scheduled task JraVanApi not found'
+            exit 1
+          }
+          if ($task.State -ne 'Disabled') {
+            Stop-ScheduledTask -TaskName 'JraVanApi'
+          }
           Start-Sleep -Seconds 2
-          # 既存のpythonプロセスを停止（ポート8000を解放）
-          Get-Process python -ErrorAction SilentlyContinue | Where-Object { $_.Path -like '*Python311*' } | Stop-Process -Force
+          # ポート8000を使用しているプロセスのみを停止
+          $portPids = (Get-NetTCPConnection -LocalPort 8000 -ErrorAction SilentlyContinue).OwningProcess | Sort-Object -Unique
+          foreach ($pid in $portPids) {
+            Write-Output "Stopping process $pid (listening on port 8000)"
+            Stop-Process -Id $pid -Force
+          }
           Start-Sleep -Seconds 2
           Start-ScheduledTask -TaskName 'JraVanApi'
           Start-Sleep -Seconds 5
@@ -382,8 +393,14 @@ jobs:
           if (-not $healthy) {
             Write-Output 'Health check failed, rolling back...'
             Copy-Item -Path "$backupDir\*" -Destination $deployDir -Force
-            Stop-ScheduledTask -TaskName 'JraVanApi' -ErrorAction SilentlyContinue
-            Get-Process python -ErrorAction SilentlyContinue | Where-Object { $_.Path -like '*Python311*' } | Stop-Process -Force
+            if ($task.State -ne 'Disabled') {
+              Stop-ScheduledTask -TaskName 'JraVanApi'
+            }
+            $portPids = (Get-NetTCPConnection -LocalPort 8000 -ErrorAction SilentlyContinue).OwningProcess | Sort-Object -Unique
+            foreach ($pid in $portPids) {
+              Write-Output "Stopping process $pid (listening on port 8000)"
+              Stop-Process -Id $pid -Force
+            }
             Start-Sleep -Seconds 2
             Start-ScheduledTask -TaskName 'JraVanApi'
             Write-Output 'Rollback complete'


### PR DESCRIPTION
## Summary
- JraVanApiはWindowsサービスではなくTask Schedulerで管理されていた
- `Restart-Service`を`Stop/Start-ScheduledTask`に変更
- pythonプロセスも明示的にStop-Processしてポート8000を解放
- ロールバック時も同様に修正

## Test plan
- [ ] `workflow_dispatch`でdeploy-ec2ジョブが成功することを確認
- [ ] ヘルスチェック通過をSSMログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)