### PR TITLE
fix: 買い目提案の信頼度を相対評価に変更し全件「高」を解消

### DIFF
--- a/backend/agentcore/tools/bet_proposal.py
+++ b/backend/agentcore/tools/bet_proposal.py
@@ -337,13 +337,11 @@ def _assign_relative_confidence(bets: list[dict]) -> None:
 
     # 3件以上: 上位1/3, 中位, 下位1/3
     high_count = max(1, round(n / 3))
-    low_count = max(1, round(n / 3))
-    # medium は残り（最低0）
-    medium_count = n - high_count - low_count
+    # medium は残り（最低0）、low は残りの要素数
+    medium_count = n - high_count - max(1, round(n / 3))
     if medium_count < 0:
-        # n=3で high_count=1, low_count=1 → medium=1 なので通常到達しない
+        # n=3で high_count=1 → lowも1、medium=1 となるため通常は到達しない
         high_count = 1
-        low_count = 1
         medium_count = n - 2
 
     for rank, idx in enumerate(indexed):
@@ -581,6 +579,10 @@ def _generate_bet_candidates(
 
     # 信頼度を候補リスト内のスコア分布に基づいて相対的に再割り当て
     _assign_relative_confidence(selected)
+
+    # 内部スコアはソート専用のため、ユーザー向けレスポンスからは削除する
+    for bet in selected:
+        bet.pop("_composite_score", None)
 
     return selected
 

--- a/backend/tests/agentcore/test_bet_proposal.py
+++ b/backend/tests/agentcore/test_bet_proposal.py
@@ -1050,8 +1050,8 @@ class TestGenerateBetCandidatesConfidence:
             confidences = {b["confidence"] for b in bets}
             assert len(confidences) >= 2, f"信頼度が1種類のみ: {confidences}"
 
-    def test_買い目候補にcomposite_scoreが格納される(self):
-        """各買い目に_composite_scoreが含まれる."""
+    def test_内部スコアがレスポンスから削除される(self):
+        """_composite_scoreは信頼度割り当て後にレスポンスから除去される."""
         runners = _make_runners(12)
         ai_preds = _make_ai_predictions(12)
         axis = [{"horse_number": 1, "horse_name": "テスト馬1", "composite_score": 85}]
@@ -1063,5 +1063,4 @@ class TestGenerateBetCandidatesConfidence:
             total_runners=12,
         )
         for bet in bets:
-            assert "_composite_score" in bet
-            assert isinstance(bet["_composite_score"], (int, float))
+            assert "_composite_score" not in bet


### PR DESCRIPTION
## Summary
- 買い目提案の信頼度が全件「高」になる問題を修正
- 絶対閾値（スコア>=70で「高」）から相対評価（候補内の順位ベース）に変更
- 上位1/3「高」・中位「中」・下位1/3「低」の分布で予算配分の傾斜が機能するように

## Background
複合スコアの分布が60-78に集中するため、閾値70を超える候補がほぼ全てとなり、信頼度が「高」一色になっていた。これにより予算配分の傾斜（高50%/中30%/低20%）が無意味になっていた。

## Changes
- `bet_proposal.py`: `_assign_relative_confidence()` 関数を新規追加
- 3箇所のインライン信頼度判定（絶対閾値）を削除し、候補選定後に一括で相対割り当て
- 各買い目dictに `_composite_score` キーを追加（相対評価の根拠として使用）

## Test plan
- [x] `_assign_relative_confidence` の単体テスト 9件追加（空リスト、1件、2件、3件、8件、同スコア、スコアなし等）
- [x] `_generate_bet_candidates` が信頼度にばらつきを生むことの結合テスト 2件追加
- [x] 全1819テスト通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)