### PR TITLE
fix: AI相談の提案質問がマークダウン生テキストで表示される不具合を修正

### DIFF
--- a/backend/agentcore/agent.py
+++ b/backend/agentcore/agent.py
@@ -188,9 +188,9 @@ def _extract_suggested_questions(text: str) -> tuple[str, list[str]]:
     Returns:
         (本文, 提案リスト) のタプル
     """
-    # 正規表現でセパレーターのバリエーションを検出
-    pattern = r"\*{0,2}-{0,3}\s*SUGGESTED_QUESTIONS\s*-{0,3}\*{0,2}"
-    match = re.search(pattern, text)
+    # 正規表現でセパレーターのバリエーションを検出（行全体がセパレーターである場合のみ）
+    pattern = r"^\s*\*{0,2}-{0,3}\s*SUGGESTED_QUESTIONS\s*-{0,3}\*{0,2}\s*$"
+    match = re.search(pattern, text, flags=re.MULTILINE)
 
     if not match:
         return text.strip(), []

--- a/backend/tests/agentcore/test_agent.py
+++ b/backend/tests/agentcore/test_agent.py
@@ -107,10 +107,9 @@ def _extract_suggested_questions(text: str) -> tuple[str, list[str]]:
     """
     import re
 
-    # 正規表現でセパレーターのバリエーションを検出
-    # ---SUGGESTED_QUESTIONS---, **SUGGESTED_QUESTIONS---**, **SUGGESTED_QUESTIONS** 等
-    pattern = r"\*{0,2}-{0,3}\s*SUGGESTED_QUESTIONS\s*-{0,3}\*{0,2}"
-    match = re.search(pattern, text)
+    # 正規表現でセパレーターのバリエーションを検出（行全体がセパレーターである場合のみ）
+    pattern = r"^\s*\*{0,2}-{0,3}\s*SUGGESTED_QUESTIONS\s*-{0,3}\*{0,2}\s*$"
+    match = re.search(pattern, text, flags=re.MULTILINE)
 
     if not match:
         return text.strip(), []

--- a/frontend/src/pages/ConsultationPage.tsx
+++ b/frontend/src/pages/ConsultationPage.tsx
@@ -328,6 +328,7 @@ export function ConsultationPage() {
                   {msg.suggestedQuestions.map((q, i) => (
                     <button
                       key={i}
+                      type="button"
                       className="suggested-question-btn"
                       onClick={() => handleSuggestedQuestion(q)}
                     >

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1792,18 +1792,18 @@ main {
 .suggested-questions {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 8px;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
     padding-right: 40px;
 }
 
 .suggested-question-btn {
-    padding: 8px 14px;
-    border: 1px solid #1a5f2a;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-calm-green);
     border-radius: 18px;
     background: white;
-    color: #1a5f2a;
-    font-size: 13px;
+    color: var(--color-calm-green);
+    font-size: var(--font-size-sm);
     cursor: pointer;
     transition: background 0.2s, color 0.2s;
     text-align: left;
@@ -1811,8 +1811,13 @@ main {
 }
 
 .suggested-question-btn:hover {
-    background: #1a5f2a;
+    background: var(--color-calm-green);
     color: white;
+}
+
+.suggested-question-btn:focus-visible {
+    outline: 2px solid var(--color-calm-green);
+    outline-offset: 2px;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- AI相談ページで `**SUGGESTED_QUESTIONS---**` が太字テキストとして表示されるバグを修正
- バックエンド: セパレータ抽出を正規表現化してAIの出力バリエーション（マークダウン太字など）に対応
- フロントエンド: `suggested_questions` をクリック可能なボタンとして表示

## Test plan
- [x] バックエンドテスト（新規3件含む11件）パス
- [x] フロントエンドテスト（29件）パス
- [ ] 本番環境でAI相談を開き、提案質問ボタンが表示されることを確認
- [ ] ボタンクリックでテキスト入力欄に質問が入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)