### PR TITLE
fix: EC2デプロイのPowerShellエラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -359,10 +359,13 @@ jobs:
           }
           Start-Sleep -Seconds 2
           # ポート8000を使用しているプロセスのみを停止（LISTENに限定）
-          $portPids = (Get-NetTCPConnection -LocalPort 8000 -State Listen -ErrorAction SilentlyContinue).OwningProcess | Sort-Object -Unique
-          foreach ($procId in $portPids) {
-            Write-Output "Stopping process $procId (using port 8000)"
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+          $connections = Get-NetTCPConnection -LocalPort 8000 -State Listen -ErrorAction SilentlyContinue
+          if ($connections) {
+            $portPids = $connections.OwningProcess | Sort-Object -Unique
+            foreach ($procId in $portPids) {
+              Write-Output "Stopping process $procId (using port 8000)"
+              Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+            }
           }
           Start-Sleep -Seconds 2
           Start-ScheduledTask -TaskName 'JraVanApi'
@@ -392,10 +395,13 @@ jobs:
             Write-Output 'Health check failed, rolling back...'
             Copy-Item -Path "$backupDir\*" -Destination $deployDir -Force
             Stop-ScheduledTask -TaskName 'JraVanApi' -ErrorAction SilentlyContinue
-            $portPids = (Get-NetTCPConnection -LocalPort 8000 -State Listen -ErrorAction SilentlyContinue).OwningProcess | Sort-Object -Unique
-            foreach ($procId in $portPids) {
-              Write-Output "Stopping process $procId (using port 8000)"
-              Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+            $connections = Get-NetTCPConnection -LocalPort 8000 -State Listen -ErrorAction SilentlyContinue
+            if ($connections) {
+              $portPids = $connections.OwningProcess | Sort-Object -Unique
+              foreach ($procId in $portPids) {
+                Write-Output "Stopping process $procId (using port 8000)"
+                Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+              }
             }
             Start-Sleep -Seconds 2
             Start-ScheduledTask -TaskName 'JraVanApi'


### PR DESCRIPTION
## Summary
- EC2デプロイ時のPowerShellスクリプトで`Set-StrictMode -Version Latest`有効環境下、`Get-NetTCPConnection`の結果が`$null`の場合に`.OwningProcess`プロパティアクセスで`PropertyNotFoundStrict`エラーが発生していた
- 結果を変数に格納し、nullチェックを追加して修正（2箇所：通常デプロイ時・ロールバック時）

## Test plan
- [ ] CIパス確認
- [ ] mainマージ後、EC2デプロイジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)