### PR TITLE
feat: 質問カテゴリ分類によるインテリジェントツールルーティング (#160)

### DIFF
--- a/backend/tests/agentcore/test_tool_router.py
+++ b/backend/tests/agentcore/test_tool_router.py
@@ -121,6 +121,18 @@ class TestClassifyQuestion:
         result = classify_question("")
         assert result == "followup"
 
+    def test_カートありでキーワードなしはfollowup(self):
+        result = classify_question("ありがとう", has_cart=True)
+        assert result == "followup"
+
+    def test_出走馬ありでキーワードなしはfollowup(self):
+        result = classify_question("なるほど", has_runners=True)
+        assert result == "followup"
+
+    def test_カートと出走馬ありでキーワードなしはfollowup(self):
+        result = classify_question("わかりました", has_cart=True, has_runners=True)
+        assert result == "followup"
+
     # --- 複数カテゴリのキーワードを含む場合 ---
 
     def test_複数カテゴリは最多ヒットのカテゴリ(self):


### PR DESCRIPTION
## Summary
- 質問カテゴリ分類器（6カテゴリ: full_analysis/horse_focused/bet_focused/race_focused/risk_focused/followup）を実装
- カテゴリに応じたプロンプト誘導でツール選択を最適化し、不要なツール呼び出しを削減
- followupカテゴリでは新規ツール呼び出し不要の簡潔回答を促進

## Test plan
- [ ] バックエンドテスト（40件）が全パスすること
- [ ] 既存テスト（834件）が全パスすること
- [ ] 本番環境でAI相談の各カテゴリ質問で適切なツール選択が行われること

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)