### PR TITLE
feat: コース適性・枠順傾向エンドポイントをjravan-apiに追加 (#34)

### DIFF
--- a/jravan-api/tests/test_course_aptitude.py
+++ b/jravan-api/tests/test_course_aptitude.py
@@ -1,0 +1,273 @@
+"""コース適性エンドポイントのテスト.
+
+GET /horses/{horse_id}/course-aptitude の単体テスト。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# pg8000 のモックを追加（Linuxテスト環境用）
+mock_pg8000 = MagicMock()
+sys.modules['pg8000'] = mock_pg8000
+
+# テスト対象モジュールへのパスを追加
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from database import (
+    get_horse_course_aptitude,
+    _classify_distance,
+    _classify_gate,
+)
+
+
+class TestClassifyDistance:
+    """_classify_distance関数のテスト."""
+
+    def test_短距離_1200m(self):
+        assert _classify_distance(1200) == "短距離"
+
+    def test_短距離_1400m(self):
+        assert _classify_distance(1400) == "短距離"
+
+    def test_マイル_1600m(self):
+        assert _classify_distance(1600) == "マイル"
+
+    def test_マイル_1800m(self):
+        assert _classify_distance(1800) == "マイル"
+
+    def test_中距離_2000m(self):
+        assert _classify_distance(2000) == "中距離"
+
+    def test_中距離_2200m(self):
+        assert _classify_distance(2200) == "中距離"
+
+    def test_長距離_2400m(self):
+        assert _classify_distance(2400) == "長距離"
+
+    def test_長距離_3600m(self):
+        assert _classify_distance(3600) == "長距離"
+
+
+class TestClassifyGate:
+    """_classify_gate関数のテスト."""
+
+    def test_内枠_1枠(self):
+        assert _classify_gate(1) == "内枠"
+
+    def test_内枠_2枠(self):
+        assert _classify_gate(2) == "内枠"
+
+    def test_中枠_3枠(self):
+        assert _classify_gate(3) == "中枠"
+
+    def test_中枠_6枠(self):
+        assert _classify_gate(6) == "中枠"
+
+    def test_外枠_7枠(self):
+        assert _classify_gate(7) == "外枠"
+
+    def test_外枠_8枠(self):
+        assert _classify_gate(8) == "外枠"
+
+
+class TestGetHorseCourseAptitude:
+    """get_horse_course_aptitude関数の単体テスト."""
+
+    @patch("database.get_db")
+    def test_正常系_コース適性データを取得できる(self, mock_get_db):
+        """複数レースの出走結果からコース適性を集計できることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        # 馬名取得 → 出走結果取得
+        mock_cursor.fetchone.return_value = ("テスト馬",)
+        mock_cursor.description = [
+            ("keibajo_code",), ("track_code",), ("kyori",),
+            ("babajotai_code_shiba",), ("babajotai_code_dirt",),
+            ("wakuban",), ("kakutei_chakujun",), ("run_time",),
+        ]
+        mock_cursor.fetchall.return_value = [
+            # 行タプル: description に従って辞書化される
+            ("09", "11", "1600", "1", "", "3", "1", "01361"),
+            ("09", "11", "1600", "1", "", "5", "3", "01365"),
+            ("05", "21", "1800", "", "1", "7", "2", "01492"),
+            ("05", "21", "1800", "", "2", "1", "5", "01510"),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_horse_course_aptitude("2021100001")
+
+        assert result is not None
+        assert result["horse_id"] == "2021100001"
+        assert result["horse_name"] == "テスト馬"
+
+        # by_venue: 阪神2走、東京2走
+        assert len(result["by_venue"]) == 2
+        hanshin = next(v for v in result["by_venue"] if v["venue"] == "阪神")
+        assert hanshin["starts"] == 2
+        assert hanshin["wins"] == 1
+        assert hanshin["places"] == 2
+
+        # by_track_type
+        assert len(result["by_track_type"]) == 2
+        turf = next(t for t in result["by_track_type"] if t["track_type"] == "芝")
+        assert turf["starts"] == 2
+        assert turf["wins"] == 1
+
+        # by_distance
+        mile = next(d for d in result["by_distance"] if d["distance_range"] == "マイル")
+        assert mile["starts"] == 4
+        assert mile["wins"] == 1
+
+        # aptitude_summary
+        summary = result["aptitude_summary"]
+        assert summary["best_venue"] == "阪神"
+
+    @patch("database.get_db")
+    def test_データが存在しない場合Noneを返す(self, mock_get_db):
+        """出走結果がない馬はNoneを返すことを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchone.return_value = None
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.description = [
+            ("keibajo_code",), ("track_code",), ("kyori",),
+            ("babajotai_code_shiba",), ("babajotai_code_dirt",),
+            ("wakuban",), ("kakutei_chakujun",), ("run_time",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_horse_course_aptitude("9999999999")
+
+        assert result is None
+
+    @patch("database.get_db")
+    def test_DBエラー時はNoneを返す(self, mock_get_db):
+        """データベースエラー時にNoneを返すことを確認."""
+        mock_get_db.return_value.__enter__.side_effect = Exception("DB Connection Error")
+
+        result = get_horse_course_aptitude("2021100001")
+
+        assert result is None
+
+    @patch("database.get_db")
+    def test_勝利なしの場合aptitude_summaryがNullになる(self, mock_get_db):
+        """全レースで勝利なしの場合、サマリーがNoneになることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchone.return_value = ("未勝利馬",)
+        mock_cursor.description = [
+            ("keibajo_code",), ("track_code",), ("kyori",),
+            ("babajotai_code_shiba",), ("babajotai_code_dirt",),
+            ("wakuban",), ("kakutei_chakujun",), ("run_time",),
+        ]
+        # 全て4着以下
+        mock_cursor.fetchall.return_value = [
+            ("09", "11", "1600", "1", "", "3", "5", "01400"),
+            ("05", "11", "2000", "1", "", "5", "8", "02050"),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_horse_course_aptitude("2022200002")
+
+        assert result is not None
+        summary = result["aptitude_summary"]
+        assert summary["best_venue"] is None
+        assert summary["best_distance"] is None
+
+    @patch("database.get_db")
+    def test_馬場状態コードが正しく変換される(self, mock_get_db):
+        """芝コースの馬場状態が正しくカテゴリ化されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchone.return_value = ("テスト馬2",)
+        mock_cursor.description = [
+            ("keibajo_code",), ("track_code",), ("kyori",),
+            ("babajotai_code_shiba",), ("babajotai_code_dirt",),
+            ("wakuban",), ("kakutei_chakujun",), ("run_time",),
+        ]
+        mock_cursor.fetchall.return_value = [
+            ("09", "11", "2000", "1", "", "3", "1", "02001"),  # 良
+            ("09", "11", "2000", "3", "", "3", "2", "02010"),  # 重
+            ("09", "11", "2000", "4", "", "3", "3", "02020"),  # 不良
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_horse_course_aptitude("2022300003")
+
+        conditions = {c["condition"]: c for c in result["by_track_condition"]}
+        assert "良" in conditions
+        assert "重" in conditions
+        assert "不良" in conditions
+        assert conditions["良"]["wins"] == 1
+
+
+class TestCourseAptitudeEndpoint:
+    """GET /horses/{horse_id}/course-aptitude エンドポイントのテスト."""
+
+    @patch("database.get_db")
+    def test_正常系_200レスポンス(self, mock_get_db):
+        """正常なリクエストで200レスポンスを返すことを確認."""
+        from fastapi.testclient import TestClient
+        from main import app
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchone.return_value = ("テスト馬",)
+        mock_cursor.description = [
+            ("keibajo_code",), ("track_code",), ("kyori",),
+            ("babajotai_code_shiba",), ("babajotai_code_dirt",),
+            ("wakuban",), ("kakutei_chakujun",), ("run_time",),
+        ]
+        mock_cursor.fetchall.return_value = [
+            ("09", "11", "1600", "1", "", "3", "1", "01361"),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        client = TestClient(app)
+        response = client.get("/horses/2021100001/course-aptitude")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["horse_id"] == "2021100001"
+        assert "by_venue" in data
+        assert "aptitude_summary" in data
+
+    @patch("database.get_db")
+    def test_存在しない馬で404レスポンス(self, mock_get_db):
+        """存在しない馬IDで404レスポンスを返すことを確認."""
+        from fastapi.testclient import TestClient
+        from main import app
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchone.return_value = None
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.description = [
+            ("keibajo_code",), ("track_code",), ("kyori",),
+            ("babajotai_code_shiba",), ("babajotai_code_dirt",),
+            ("wakuban",), ("kakutei_chakujun",), ("run_time",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        client = TestClient(app)
+        response = client.get("/horses/9999999999/course-aptitude")
+
+        assert response.status_code == 404

--- a/jravan-api/tests/test_gate_position.py
+++ b/jravan-api/tests/test_gate_position.py
@@ -1,0 +1,387 @@
+"""枠順傾向エンドポイントのテスト.
+
+GET /statistics/gate-position の単体テスト。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# pg8000 のモックを追加（Linuxテスト環境用）
+mock_pg8000 = MagicMock()
+sys.modules['pg8000'] = mock_pg8000
+
+# テスト対象モジュールへのパスを追加
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from database import (
+    get_gate_position_stats,
+    VENUE_NAME_TO_CODE,
+    TRACK_CONDITION_CODE_MAP,
+)
+
+
+class TestVenueNameToCode:
+    """VENUE_NAME_TO_CODE逆引きマッピングのテスト."""
+
+    def test_東京のコード変換(self):
+        assert VENUE_NAME_TO_CODE["東京"] == "05"
+
+    def test_阪神のコード変換(self):
+        assert VENUE_NAME_TO_CODE["阪神"] == "09"
+
+    def test_全10場が登録されている(self):
+        assert len(VENUE_NAME_TO_CODE) == 10
+
+
+class TestTrackConditionCodeMap:
+    """TRACK_CONDITION_CODE_MAP のテスト."""
+
+    def test_良は1(self):
+        assert TRACK_CONDITION_CODE_MAP["良"] == "1"
+
+    def test_不良は4(self):
+        assert TRACK_CONDITION_CODE_MAP["不良"] == "4"
+
+
+class TestGetGatePositionStats:
+    """get_gate_position_stats関数の単体テスト."""
+
+    @patch("database.get_db")
+    def test_正常系_枠順統計を取得できる(self, mock_get_db):
+        """正常なデータで枠順統計を取得できることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        # 1回目: レース取得クエリ
+        races = [
+            ("2026", "0125", "09", "01"),
+            ("2026", "0125", "09", "02"),
+        ]
+        # 2回目: 出走結果取得クエリ
+        result_rows = [
+            ("1", "1", "1"),   # 1枠1番 1着
+            ("2", "3", "2"),   # 2枠3番 2着
+            ("3", "5", "3"),   # 3枠5番 3着
+            ("4", "7", "5"),   # 4枠7番 5着
+            ("1", "2", "3"),   # 1枠2番 3着
+            ("5", "9", "1"),   # 5枠9番 1着
+            ("7", "13", "4"),  # 7枠13番 4着
+            ("8", "16", "8"),  # 8枠16番 8着
+        ]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="阪神")
+
+        assert result is not None
+        assert result["conditions"]["venue"] == "阪神"
+        assert result["total_races"] == 2
+
+        # by_gate の確認
+        assert len(result["by_gate"]) > 0
+        gate_1 = next(g for g in result["by_gate"] if g["gate"] == 1)
+        assert gate_1["starts"] == 2
+        assert gate_1["wins"] == 1
+        assert gate_1["places"] == 2
+        assert gate_1["gate_range"] == "1-2枠"
+
+        # by_horse_number の確認
+        assert len(result["by_horse_number"]) > 0
+
+        # analysis の確認
+        assert "favorable_gates" in result["analysis"]
+        assert "unfavorable_gates" in result["analysis"]
+        assert "comment" in result["analysis"]
+
+    @patch("database.get_db")
+    def test_存在しない競馬場名でNoneを返す(self, mock_get_db):
+        """存在しない競馬場名を指定した場合Noneを返すことを確認."""
+        result = get_gate_position_stats(venue="存在しない競馬場")
+
+        assert result is None
+        # DBへのアクセスなし
+        mock_get_db.assert_not_called()
+
+    @patch("database.get_db")
+    def test_レースが存在しない場合Noneを返す(self, mock_get_db):
+        """条件に合うレースがない場合Noneを返すことを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_cursor.fetchall.return_value = []  # レースなし
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="東京", distance=9999)
+
+        assert result is None
+
+    @patch("database.get_db")
+    def test_track_typeフィルタが適用される(self, mock_get_db):
+        """track_typeを指定した場合にフィルタが適用されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "05", "01")]
+        result_rows = [("3", "5", "1")]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="東京", track_type="芝")
+
+        assert result is not None
+        assert result["conditions"]["track_type"] == "芝"
+
+        # SQLにtrack_codeフィルタが含まれていることを確認
+        call_args = mock_cursor.execute.call_args_list[0]
+        sql = call_args[0][0]
+        assert "track_code LIKE '1%'" in sql
+
+    @patch("database.get_db")
+    def test_distanceフィルタが適用される(self, mock_get_db):
+        """distanceを指定した場合にフィルタが適用されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "05", "01")]
+        result_rows = [("3", "5", "1")]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="東京", distance=1600)
+
+        assert result is not None
+        assert result["conditions"]["distance"] == 1600
+
+    @patch("database.get_db")
+    def test_track_conditionフィルタが適用される(self, mock_get_db):
+        """track_conditionを指定した場合にフィルタが適用されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "09", "01")]
+        result_rows = [("1", "1", "1")]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="阪神", track_condition="重")
+
+        assert result is not None
+        assert result["conditions"]["track_condition"] == "重"
+
+    @patch("database.get_db")
+    def test_limitパラメータが適用される(self, mock_get_db):
+        """limitを指定した場合にLIMIT句が適用されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "05", "01")]
+        result_rows = [("3", "5", "1")]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="東京", limit=50)
+
+        assert result is not None
+        # LIMIT句がSQL内に含まれることを確認
+        call_args = mock_cursor.execute.call_args_list[0]
+        sql = call_args[0][0]
+        assert "LIMIT" in sql
+        params = call_args[0][1]
+        assert 50 in params
+
+    @patch("database.get_db")
+    def test_DBエラー時はNoneを返す(self, mock_get_db):
+        """データベースエラー時にNoneを返すことを確認."""
+        mock_get_db.return_value.__enter__.side_effect = Exception("DB Connection Error")
+
+        result = get_gate_position_stats(venue="東京")
+
+        assert result is None
+
+    @patch("database.get_db")
+    def test_有利不利枠の分析が正しい(self, mock_get_db):
+        """平均勝率から5%以上離れた枠が有利/不利として判定されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "09", str(i).zfill(2)) for i in range(1, 11)]
+
+        # 1枠は勝率40%（高い）、8枠は勝率0%（低い）、それ以外は平均的
+        result_rows = []
+        # 1枠: 10走4勝
+        for i in range(10):
+            result_rows.append(("1", "1", "1" if i < 4 else "5"))
+        # 2枠: 10走1勝
+        for i in range(10):
+            result_rows.append(("2", "3", "1" if i < 1 else "6"))
+        # 3枠: 10走1勝
+        for i in range(10):
+            result_rows.append(("3", "5", "1" if i < 1 else "7"))
+        # 8枠: 10走0勝
+        for i in range(10):
+            result_rows.append(("8", "16", "8"))
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="阪神")
+
+        assert result is not None
+        # 平均勝率 = 6/40 = 15%
+        # 1枠: 40% → 15%+5%=20%以上 → 有利
+        assert 1 in result["analysis"]["favorable_gates"]
+        # 8枠: 0% → 15%-5%=10%以下 → 不利
+        assert 8 in result["analysis"]["unfavorable_gates"]
+
+    @patch("database.get_db")
+    def test_差がない場合のコメント(self, mock_get_db):
+        """全枠の勝率が近い場合、差が小さいコメントが生成されることを確認."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "09", "01")]
+        # 各枠1走1勝（全て均等）
+        result_rows = [
+            ("1", "1", "1"),
+            ("2", "3", "1"),
+            ("3", "5", "1"),
+            ("4", "7", "1"),
+        ]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        result = get_gate_position_stats(venue="阪神")
+
+        assert result is not None
+        assert result["analysis"]["comment"] == "枠順による有利不利の差は小さい"
+
+
+class TestGatePositionEndpoint:
+    """GET /statistics/gate-position エンドポイントのテスト."""
+
+    @patch("database.get_db")
+    def test_正常系_200レスポンス(self, mock_get_db):
+        """正常なリクエストで200レスポンスを返すことを確認."""
+        from fastapi.testclient import TestClient
+        from main import app
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "05", "01")]
+        result_rows = [("3", "5", "1")]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        client = TestClient(app)
+        response = client.get("/statistics/gate-position?venue=東京")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["conditions"]["venue"] == "東京"
+        assert "by_gate" in data
+        assert "analysis" in data
+
+    @patch("database.get_db")
+    def test_venueパラメータ必須(self, mock_get_db):
+        """venueパラメータなしで422レスポンスを返すことを確認."""
+        from fastapi.testclient import TestClient
+        from main import app
+
+        client = TestClient(app)
+        response = client.get("/statistics/gate-position")
+
+        assert response.status_code == 422
+
+    @patch("database.get_db")
+    def test_存在しない競馬場で404レスポンス(self, mock_get_db):
+        """存在しない競馬場名で404レスポンスを返すことを確認."""
+        from fastapi.testclient import TestClient
+        from main import app
+
+        client = TestClient(app)
+        response = client.get("/statistics/gate-position?venue=存在しない")
+
+        assert response.status_code == 404
+
+    @patch("database.get_db")
+    def test_全パラメータ指定_200レスポンス(self, mock_get_db):
+        """全パラメータを指定して200レスポンスを返すことを確認."""
+        from fastapi.testclient import TestClient
+        from main import app
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        races = [("2026", "0125", "09", "01")]
+        result_rows = [("1", "1", "1")]
+
+        mock_cursor.fetchall.side_effect = [races, result_rows]
+        mock_cursor.description = [
+            ("wakuban",), ("umaban",), ("kakutei_chakujun",),
+        ]
+
+        mock_get_db.return_value.__enter__.return_value = mock_conn
+
+        client = TestClient(app)
+        response = client.get(
+            "/statistics/gate-position"
+            "?venue=阪神&track_type=芝&distance=1600&track_condition=良&limit=100"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["conditions"]["venue"] == "阪神"
+        assert data["conditions"]["track_type"] == "芝"
+        assert data["conditions"]["distance"] == 1600
+        assert data["conditions"]["track_condition"] == "良"


### PR DESCRIPTION
## Summary
- jravan-apiに2つの新規エンドポイントを追加
  - `GET /horses/{horse_id}/course-aptitude`: 馬のコース適性分析（競馬場別/トラック種別/距離帯/馬場状態/枠位置別の成績集計、aptitude_summaryで各カテゴリ最高勝率を要約）
  - `GET /statistics/gate-position`: 枠順・馬番別の成績統計（venue必須、track_type/distance/track_condition/limitで任意フィルタ、有利/不利枠の自動分析）
- `database.py`に`get_horse_course_aptitude`と`get_gate_position_stats`関数を追加
- テスト40件追加（ユーティリティ関数テスト14件、DB関数テスト16件、エンドポイントテスト10件）

## Test plan
- [x] `test_course_aptitude.py` 21件パス（距離帯分類、枠分類、コース適性集計、エンドポイント）
- [x] `test_gate_position.py` 19件パス（逆引きマッピング、枠順統計集計、各種フィルタ、有利不利分析、エンドポイント）
- [x] 既存テスト（test_statistics.py等）に影響なし

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)