### PR TITLE
fix: 金額ステッパーの−ボタンがクリックできない問題を修正

### DIFF
--- a/frontend/src/pages/RaceDetailPage.css
+++ b/frontend/src/pages/RaceDetailPage.css
@@ -190,10 +190,13 @@
 }
 
 .currency-symbol {
+  position: static;
+  transform: none;
   font-size: 16px;
   font-weight: 600;
   color: #666;
   flex-shrink: 0;
+  pointer-events: none;
 }
 
 .amount-input {


### PR DESCRIPTION
## Summary
- レース詳細ページの金額入力で「−」ボタンがクリックできない問題を修正
- `index.css`のグローバル`.currency-symbol`が`position: absolute`を設定しており、`RaceDetailPage`内の¥記号が−ボタンに重なってポインターイベントを遮っていた
- `position: static`でオーバーライドし、`pointer-events: none`を追加

## 再現手順
1. レース詳細ページを開く
2. 金額入力の「−」ボタンをクリック → クリックが通らない

## 原因
- `index.css:757`のグローバル`.currency-symbol`が`position: absolute; left: 14px;`を設定
- `RaceDetailPage.css:192`が同名クラスだが`position`をオーバーライドしていない
- ¥記号がabsolute配置で−ボタンの上に重なり、クリックイベントを遮断

## Test plan
- [ ] レース詳細ページで「−」ボタンをクリックして金額が減少することを確認
- [ ] 「＋」ボタンが引き続き動作することを確認
- [ ] ¥記号の表示位置が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)