### PR TITLE
fix: カートの買い目追加ボタンのラベルとナビゲーションを修正

### DIFF
--- a/frontend/src/pages/CartPage.test.tsx
+++ b/frontend/src/pages/CartPage.test.tsx
@@ -76,5 +76,12 @@ describe('CartPage', () => {
       const aiButton = screen.getByRole('button', { name: /AI 買い目レビュー/i })
       expect(aiButton).toBeInTheDocument()
     })
+
+    it('「このレースに買い目を追加」ボタンが表示される', () => {
+      render(<CartPage />)
+
+      const addMoreBtn = screen.getByRole('button', { name: /このレースに買い目を追加/ })
+      expect(addMoreBtn).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/pages/CartPage.tsx
+++ b/frontend/src/pages/CartPage.tsx
@@ -143,8 +143,8 @@ export function CartPage() {
             </div>
           )}
 
-          <button className="add-more-btn" onClick={() => navigate('/')}>
-            ＋ 別のレースの買い目を追加
+          <button className="add-more-btn" onClick={() => navigate(`/races/${items[0].raceId}`)}>
+            ＋ このレースに買い目を追加
           </button>
           <button
             className="btn-ai-confirm"


### PR DESCRIPTION
## Summary
- カートページの「＋ 別のレースの買い目を追加」ボタンのラベルを「＋ このレースに買い目を追加」に変更
- ナビゲーション先をレース一覧（`/`）からカート内のレース詳細ページ（`/races/{raceId}`）に変更
- `cartStore`は同一レースの買い目のみ許可しているため、UIとロジックの矛盾を解消

## Test plan
- [x] CartPage既存テスト8件通過
- [x] 新規テスト「このレースに買い目を追加」ボタンの表示確認追加
- [ ] 本番環境でボタンラベルと遷移先を確認

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)