### PR TITLE
fix: IPAT残高取得のHTTPタイムアウトを引き上げ

### DIFF
--- a/backend/src/infrastructure/providers/jravan_ipat_gateway.py
+++ b/backend/src/infrastructure/providers/jravan_ipat_gateway.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class JraVanIpatGateway(IpatGateway):
     """JRA-VAN jravan-api 経由の IPAT ゲートウェイ."""
 
-    DEFAULT_TIMEOUT = 10
+    DEFAULT_TIMEOUT = 25
 
     def __init__(self, base_url: str | None = None, timeout: int | None = None) -> None:
         """初期化."""


### PR DESCRIPTION
## Summary
- JraVanIpatGateway の DEFAULT_TIMEOUT を10秒→25秒に引き上げ
- ipatgo.exe stat の実行が10秒を超えてLambda側でRead Timeoutが発生していた
- Lambda自体は30秒タイムアウトのため、25秒に設定して余裕を持たせる

## Root Cause
CloudWatchログより `HTTPConnectionPool(host='10.0.0.203', port=8000): Read timed out. (read timeout=10)` を確認。EC2上の `stat.ini` タイムスタンプから ipatgo.exe は正常完了しているが、HTTPレスポンスが10秒以内に返らなかった。

## Test plan
- [x] `test_jravan_ipat_gateway.py` 全6テスト PASSED
- [ ] デプロイ後に本番で残高取得が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)