### PR TITLE
fix: JRA出馬表チェックサムの古いデータによる不正リンクを防止

### DIFF
--- a/jravan-api/database.py
+++ b/jravan-api/database.py
@@ -6,7 +6,7 @@ pg8000 (pure Python PostgreSQL driver) を使用。
 import logging
 import os
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from pathlib import Path
 from dotenv import load_dotenv
@@ -1270,10 +1270,10 @@ def get_jra_checksum(venue_code: str, kaisai_kai: str, kaisai_nichime: int, race
         updated_at = row[1]
 
         if updated_at is not None:
-            from datetime import datetime, timedelta, timezone as tz
-            now = datetime.now(tz(timedelta(hours=9)))
+            jst = timezone(timedelta(hours=9))
+            now = datetime.now(jst)
             if updated_at.tzinfo is None:
-                updated_at = updated_at.replace(tzinfo=tz(timedelta(hours=9)))
+                updated_at = updated_at.replace(tzinfo=jst)
             age = now - updated_at
             if age > timedelta(days=CHECKSUM_STALENESS_DAYS):
                 logger.warning(

--- a/jravan-api/tests/test_jra_checksum_scraper.py
+++ b/jravan-api/tests/test_jra_checksum_scraper.py
@@ -356,11 +356,12 @@ class TestScrapeJraChecksums:
         mock_db.get_current_kaisai_info.return_value = []
 
         # ブルートフォースで東京05/01/nichime=3 で見つかる想定
+        # 第2要素のチェックサム値は本テストでは使用しないダミー値
         mock_find.return_value = ("<html>valid page</html>", 0xAB)
 
         mock_extract.return_value = {
             "pw01dde0105202601030120260207": 196,  # 東京1R
-            "pw01dde0105202601030220260207": 100,  # 東京2R（1R以外は無視）
+            "pw01dde0105202601030220260207": 100,  # 東京2R（_discover_venues_from_navで除外される）
             "pw01dde0108202602030120260207": 40,   # 京都1R
         }
 


### PR DESCRIPTION
## Summary
- JRA出馬表リンクのチェックサムが古いデータのまま使用され、クリック時に「パラメータエラー」が表示される問題を修正
- `get_jra_checksum` に7日間のstaleness checkを追加し、古いbase_valueによる不正チェックサム生成を防止
- スクレイパーをDB非依存化し、`jvd_ra` テーブルにデータがなくてもJRAサイトから直接会場情報を検出可能に
- バッチLambdaにEC2接続エラー時の指数バックオフリトライ（最大3回）を追加

## Test plan
- [x] バックエンド全2176テスト Pass
- [x] フロントエンド全445テスト Pass
- [x] CDK全74テスト Pass
- [ ] CI/CD成功確認
- [ ] 本番環境で出馬表リンクの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)