### PR TITLE
fix: IPAT投票の競馬場コードを英語名に修正

### DIFF
--- a/backend/src/infrastructure/providers/jravan_ipat_gateway.py
+++ b/backend/src/infrastructure/providers/jravan_ipat_gateway.py
@@ -45,7 +45,7 @@ class JraVanIpatGateway(IpatGateway):
             bet_line_dicts = [
                 {
                     "opdt": line.opdt,
-                    "rcoursecd": line.venue_code.value,
+                    "rcoursecd": line.venue_code.name,
                     "rno": f"{line.race_number:02d}",
                     "denomination": line.bet_type.value,
                     "method": "NORMAL",

--- a/backend/tests/infrastructure/providers/test_jravan_ipat_gateway.py
+++ b/backend/tests/infrastructure/providers/test_jravan_ipat_gateway.py
@@ -44,6 +44,23 @@ class TestJraVanIpatGateway(unittest.TestCase):
         assert result is True
 
     @patch("src.infrastructure.providers.jravan_ipat_gateway.requests.Session")
+    def test_投票送信_競馬場コードが英語名で送信される(self, mock_session_cls: MagicMock) -> None:
+        """ipatgo.exeはrcoursecdに英語名（TOKYO等）を期待する."""
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True}
+        mock_session.post.return_value = mock_response
+        mock_session_cls.return_value = mock_session
+        self.gateway._session = mock_session
+
+        self.gateway.submit_bets(self.credentials, self.bet_lines)
+
+        call_args = mock_session.post.call_args
+        payload = call_args[1]["json"]
+        assert payload["bet_lines"][0]["rcoursecd"] == "TOKYO"
+
+    @patch("src.infrastructure.providers.jravan_ipat_gateway.requests.Session")
     def test_投票送信_失敗(self, mock_session_cls: MagicMock) -> None:
         mock_session = MagicMock()
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary
- ipatgo.exeはCSVのrcoursecdフィールドに英語名（`TOKYO`, `KOKURA`等）を期待するが、数字コード（`05`, `10`等）を渡していたため投票が失敗していた
- `IpatVenueCode.value`（数字）→ `IpatVenueCode.name`（英語名）に変更
- ipatgo.exeログ: `競馬場コードが異常` → 修正後は正しいコードが渡される

## Test plan
- [x] 新規テスト `test_投票送信_競馬場コードが英語名で送信される` 追加・パス
- [x] 全バックエンドテスト 2196件パス
- [ ] 本番環境で投票実行して成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)