### PR TITLE
fix: IPAT残高計算でtotal_vote_amountの不要な減算を削除

### DIFF
--- a/jravan-api/ipat_executor.py
+++ b/jravan-api/ipat_executor.py
@@ -103,15 +103,14 @@ class IpatExecutor:
         """stat.iniをパースし残高情報を返す.
 
         ipatgo.exe stat が出力する stat.ini のフィールドから残高を計算する。
-        - limit_vote_amount: IPAT投票限度額（入金額ベース）
-        - total_vote_amount: 累計投票金額
+        - limit_vote_amount: IPAT投票限度額（投票済み額を反映した残高）
         - total_repayment: 累計払戻金額
 
         Returns:
             dict: 残高情報
-                - bet_dedicated_balance: 投票専用残高（限度額 - 累計投票額）
+                - bet_dedicated_balance: 投票専用残高（限度額）
                 - settle_possible_balance: 精算可能残高（払戻金額）
-                - bet_balance: 投票可能残高（専用残高 + 精算可能残高）
+                - bet_balance: 投票可能残高（限度額 + 精算可能残高）
                 - limit_vote_amount: 投票限度額
         """
         config = configparser.ConfigParser()
@@ -128,11 +127,10 @@ class IpatExecutor:
 
         stat = config["stat"]
         limit = int(stat.get("limit_vote_amount", 0))
-        voted = int(stat.get("total_vote_amount", 0))
         repayment = int(stat.get("total_repayment", 0))
         return {
-            "bet_dedicated_balance": limit - voted,
+            "bet_dedicated_balance": limit,
             "settle_possible_balance": repayment,
-            "bet_balance": limit - voted + repayment,
+            "bet_balance": limit + repayment,
             "limit_vote_amount": limit,
         }

--- a/jravan-api/tests/test_ipat_executor.py
+++ b/jravan-api/tests/test_ipat_executor.py
@@ -174,11 +174,11 @@ limit_vote_amount=100000
             result = self.executor.stat("ABcd1234", "12345678", "1234", "5678")
 
         assert result["success"] is True
-        # limit(100000) - voted(10000) = 90000
-        assert result["bet_dedicated_balance"] == 90000
+        # limit_vote_amountは既に投票済み額を反映した残高
+        assert result["bet_dedicated_balance"] == 100000
         assert result["settle_possible_balance"] == 5000
-        # limit(100000) - voted(10000) + repayment(5000) = 95000
-        assert result["bet_balance"] == 95000
+        # limit(100000) + repayment(5000) = 105000
+        assert result["bet_balance"] == 105000
         assert result["limit_vote_amount"] == 100000
 
     @patch("ipat_executor.IpatExecutor._check_ipatgo", return_value=None)
@@ -202,11 +202,11 @@ limit_vote_amount=100000
         with patch("builtins.open", mock_open(read_data=ini_content)):
             result = self.executor._parse_stat_ini()
 
-        # limit(100000) - voted(10000) = 90000
-        assert result["bet_dedicated_balance"] == 90000
+        # limit_vote_amountは既に投票済み額を反映した残高
+        assert result["bet_dedicated_balance"] == 100000
         assert result["settle_possible_balance"] == 5000
-        # limit(100000) - voted(10000) + repayment(5000) = 95000
-        assert result["bet_balance"] == 95000
+        # limit(100000) + repayment(5000) = 105000
+        assert result["bet_balance"] == 105000
         assert result["limit_vote_amount"] == 100000
 
     def test_parse_stat_iniでstatセクションがない場合全て0を返す(self) -> None:
@@ -231,9 +231,9 @@ limit_vote_amount=200000
         with patch("builtins.open", mock_open(read_data=ini_content)):
             result = self.executor._parse_stat_ini()
 
-        # limit(200000) - voted(5000) = 195000
-        assert result["bet_dedicated_balance"] == 195000
+        # limit_vote_amountをそのまま使用（total_vote_amountは引かない）
+        assert result["bet_dedicated_balance"] == 200000
         assert result["settle_possible_balance"] == 0
-        # limit(200000) - voted(5000) + repayment(0) = 195000
-        assert result["bet_balance"] == 195000
+        # limit(200000) + repayment(0) = 200000
+        assert result["bet_balance"] == 200000
         assert result["limit_vote_amount"] == 200000


### PR DESCRIPTION
## Summary
- `_parse_stat_ini()` で `limit_vote_amount - total_vote_amount` と計算していたが、`limit_vote_amount` は既に投票済み額を反映した残高のため二重減算になっていた
- `total_vote_amount` の減算を削除し、`bet_dedicated_balance = limit`、`bet_balance = limit + repayment` に修正

## Test plan
- [x] jravan-api テスト 12件 PASSED
- [x] backend テスト 2198件 PASSED
- [ ] デプロイ後に本番で残高が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)