### PR TITLE
docs: CLAUDE.mdに専門家チーム編成の作業方針を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ cd backend && pytest
 - `/copilot-review` - GitHub Copilot PRレビュー対応
 - `/verification` - 本番環境（bakenkaigi.com）動作確認
 
+## 作業方針
+
+- 実装タスクには専門家チームを編成し、役割分担と並列作業で対応する
+
 ## 注意事項
 
 - セキュリティ最優先（IAM最小権限、シークレット管理）


### PR DESCRIPTION
## Summary
- CLAUDE.mdに「作業方針」セクションを追加
- 実装タスクには専門家チームを編成し、役割分担と並列作業で対応する旨を明記

## Test plan
- [x] CLAUDE.mdの構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)