### PR TITLE
feat: bankrollモードによる資金配分ロジックの再設計

### DIFF
--- a/backend/tests/agentcore/test_bet_proposal.py
+++ b/backend/tests/agentcore/test_bet_proposal.py
@@ -2323,8 +2323,20 @@ class TestGenerateBetCandidatesNoMaxBets:
             bet_types=["quinella", "trio"],
             total_runners=12,
         )
-        # 旧仕様では8点が上限だったが、新仕様ではmax_bets=Noneで全件返される
+        # max_bets=None（デフォルト）で8点を超える買い目が返される
         assert isinstance(result, list)
+        assert len(result) > 8, f"MAX_BETS制限撤廃後は8点超を期待するが {len(result)}点"
+
+        # max_bets=8を明示すると8点以下に制限される
+        result_limited = _generate_bet_candidates(
+            axis_horses=axis,
+            runners_data=runners,
+            ai_predictions=preds,
+            bet_types=["quinella", "trio"],
+            total_runners=12,
+            max_bets=8,
+        )
+        assert len(result_limited) <= 8
 
 
 class TestBankrollMode:

--- a/docs/plans/2026-02-14-budget-allocation-redesign.md
+++ b/docs/plans/2026-02-14-budget-allocation-redesign.md
@@ -12,7 +12,7 @@
 
 ## 前提知識
 
-- ワークツリー: `/home/inoue-d/dev/baken-kaigi/feat-budget-redesign`
+- ワークツリー: `./feat-budget-redesign`
 - 対象ファイル: `backend/agentcore/tools/bet_proposal.py`
 - テストファイル: `backend/tests/agentcore/test_bet_proposal.py`
 - テスト実行: `cd backend && uv run pytest tests/agentcore/test_bet_proposal.py -v`


### PR DESCRIPTION
## Summary
- bankroll(総資金)を指定すると、レースごとの予算を自動算出する**bankrollモード**を追加
- Stage1(レース間配分): `race_budget = bankroll × base_rate × confidence_factor` で見送りスコアに応じた傾斜配分
- Stage2(レース内配分): ダッチング(オッズ逆比例)で均等払い戻しを実現
- EV > 1.0の買い目のみ採用し、MAX_BETS=8の固定上限を撤廃
- 従来のbudget指定モードは完全に互換性を維持

## Changes
- `_calculate_confidence_factor`: 見送りスコア(0-10)から信頼度係数(0.0-2.0)を算出
- `_allocate_budget_dutching`: ダッチング方式で買い目に資金配分（予算超過時は再帰的に最小配分の買い目を除外）
- `_generate_bet_candidates`: `max_bets`をオプショナルに変更（bankrollモードでは全件返却）
- `_generate_bet_proposal_impl`: bankroll > 0 時にbankrollモード分岐
- `generate_bet_proposal` @tool: `bankroll`引数追加
- ペルソナ設定: `base_rate`追加（conservative: 2%, default: 3%, aggressive: 5%）

## Test plan
- [x] 178テスト全パス（26テスト新規追加）
- [x] `TestCalculateConfidenceFactor`: 見送りスコア→信頼度係数の変換（6テスト）
- [x] `TestBaseRateConfig`: ペルソナ別base_rate設定（4テスト）
- [x] `TestAllocateBudgetDutching`: ダッチング配分ロジック（10テスト）
- [x] `TestGenerateBetCandidatesNoMaxBets`: MAX_BETS制限撤廃（1テスト）
- [x] `TestBankrollMode`: bankrollモード統合テスト（5テスト）
- [x] 全2291テストリグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)