### PR TITLE
fix: SinglePageAppの馬テーブルから枠インジケーター列を削除

### DIFF
--- a/frontend/src/pages/SinglePageApp.tsx
+++ b/frontend/src/pages/SinglePageApp.tsx
@@ -443,7 +443,6 @@ export function SinglePageApp() {
             <table className="dashboard-table">
               <thead>
                 <tr>
-                  <th></th>
                   <th>馬番</th>
                     <th style={{ textAlign: 'left', paddingLeft: 10 }}>馬名</th>
                     <th className="td-finish-position">着順</th>
@@ -465,12 +464,6 @@ export function SinglePageApp() {
                 <tbody>
                   {race.horses.map((horse: Horse) => (
                       <tr key={horse.number}>
-                        <td className="td-waku">
-                          <div
-                            className="waku-indicator"
-                            style={{ backgroundColor: horse.color }}
-                          />
-                        </td>
                         <td className="td-horse-number">
                           <span
                             className="horse-num-circle"


### PR DESCRIPTION
## Summary
- 馬番の円に既に枠色が付いているため、冗長な枠インジケーター列（td-waku）を削除

## Test plan
- [ ] フロントエンドテスト通過確認（462 passed）
- [ ] 本番でテーブルレイアウトが崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)