### PR TITLE
fix: RaceDashboardPageから冗長な枠インジケーター列を削除

### DIFF
--- a/frontend/src/pages/RaceDashboardPage.css
+++ b/frontend/src/pages/RaceDashboardPage.css
@@ -509,19 +509,6 @@
   accent-color: var(--color-primary);
 }
 
-/* Waku border indicator */
-.td-waku {
-  width: 6px;
-  padding: 0 !important;
-}
-
-.waku-indicator {
-  width: 4px;
-  height: 28px;
-  border-radius: 2px;
-  margin: 0 auto;
-}
-
 /* Horse number */
 .td-horse-number {
   width: 36px;

--- a/frontend/src/pages/RaceDashboardPage.tsx
+++ b/frontend/src/pages/RaceDashboardPage.tsx
@@ -387,7 +387,6 @@ export function RaceDashboardPage() {
             <thead>
               <tr>
                 <th></th>
-                <th></th>
                 <th>馬番</th>
                 <th style={{ textAlign: 'left', paddingLeft: 10 }}>馬名</th>
                 <th className="td-finish-position">着順</th>
@@ -423,14 +422,6 @@ export function RaceDashboardPage() {
                         checked={selected}
                         onChange={() => toggleHorseSelection(horse.number)}
                         onClick={(e) => e.stopPropagation()}
-                      />
-                    </td>
-
-                    {/* Waku color indicator */}
-                    <td className="td-waku">
-                      <div
-                        className="waku-indicator"
-                        style={{ backgroundColor: horse.color }}
                       />
                     </td>
 


### PR DESCRIPTION
## Summary
- `RaceDashboardPage.tsx` から枠インジケーター列（`td-waku` / `waku-indicator`）を削除
- `RaceDashboardPage.css` から対応するDead CSSを削除
- PR #594 でSinglePageAppから同様の削除を行ったが、RaceDashboardPage側が残っていた

## Background
`horse-num-circle` に既に `backgroundColor: horse.color` が適用されているため、隣の枠インジケーター列は同じ色情報の重複表示だった。

## Test plan
- [ ] 本番環境でレースダッシュボードの馬テーブルが正常に表示されることを確認
- [ ] 馬番の枠色表示が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)