### PR TITLE
fix: 全スクレーパーからDynamoDBアイテムのTTLを削除

### DIFF
--- a/backend/batch/ai_shisu_scraper.py
+++ b/backend/batch/ai_shisu_scraper.py
@@ -22,7 +22,6 @@ logger.setLevel(logging.INFO)
 BASE_URL = "https://www.ai-shisu.com"
 EVENT_DATES_URL = f"{BASE_URL}/event_dates"
 SOURCE_NAME = "ai-shisu"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0  # サーバー負荷軽減のための遅延
 
 # タイムゾーン
@@ -210,9 +209,6 @@ def save_predictions(
     scraped_at: datetime,
 ) -> None:
     """予想データをDynamoDBに保存."""
-    # TTL計算（7日後）
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -220,7 +216,6 @@ def save_predictions(
         "race_number": race_number,
         "predictions": predictions,
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/daily_speed_index_scraper.py
+++ b/backend/batch/daily_speed_index_scraper.py
@@ -36,7 +36,6 @@ logger.setLevel(logging.INFO)
 # 定数
 SOURCE_NAME = "daily-speed"
 BASE_URL = "https://www.daily.co.jp/horse/speed"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 2.0  # 大手メディアサイトなので長めに設定
 
 # タイムゾーン
@@ -236,8 +235,6 @@ def save_indices(
     scraped_at: datetime,
 ) -> None:
     """スピード指数データをDynamoDBに保存."""
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -245,7 +242,6 @@ def save_indices(
         "race_number": race_number,
         "indices": convert_floats(indices),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/hrdb_race_scraper.py
+++ b/backend/batch/hrdb_race_scraper.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 JST = timezone(timedelta(hours=9))
-TTL_DAYS = 14
 
 TRACK_TYPE_MAP = {
     "1": "芝",
@@ -82,7 +81,6 @@ def convert_race_row(row: dict, scraped_at: datetime) -> dict:
         "kaisai_kai": row["KAI"].strip(),
         "kaisai_nichime": row["NITIME"].strip(),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": int((scraped_at + timedelta(days=TTL_DAYS)).timestamp()),
     }
     return {k: v for k, v in item.items() if v is not None}
 
@@ -125,7 +123,6 @@ def convert_runner_row(row: dict, scraped_at: datetime) -> dict:
         "weight": _safe_int(wght) if wght and wght != "000" else None,
         "weight_diff": int(zogendiff) * (-1 if zogensign == "-" else 1) if zogendiff and _safe_int(zogendiff) is not None and zogensign in ("+", "-", "0") else None,
         "scraped_at": scraped_at.isoformat(),
-        "ttl": int((scraped_at + timedelta(days=TTL_DAYS)).timestamp()),
     }
 
     # DynamoDBはNone値を受け付けないためフィルタ

--- a/backend/batch/jiro8_speed_index_scraper.py
+++ b/backend/batch/jiro8_speed_index_scraper.py
@@ -36,7 +36,6 @@ logger.setLevel(logging.INFO)
 # 定数
 SOURCE_NAME = "jiro8-speed"
 BASE_URL = "https://jiro8.sakura.ne.jp"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0
 
 # タイムゾーン
@@ -244,8 +243,6 @@ def save_indices(
     scraped_at: datetime,
 ) -> None:
     """スピード指数データをDynamoDBに保存."""
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -253,7 +250,6 @@ def save_indices(
         "race_number": race_number,
         "indices": convert_floats(indices),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/keiba_ai_athena_scraper.py
+++ b/backend/batch/keiba_ai_athena_scraper.py
@@ -30,7 +30,6 @@ logger.setLevel(logging.INFO)
 # 定数
 BASE_URL = "https://keiba-ai.jp"
 SOURCE_NAME = "keiba-ai-athena"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0  # サーバー負荷軽減のための遅延
 
 # タイムゾーン
@@ -252,9 +251,6 @@ def save_predictions(
     scraped_at: datetime,
 ) -> None:
     """予想データをDynamoDBに保存."""
-    # TTL計算（7日後）
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -262,7 +258,6 @@ def save_predictions(
         "race_number": race_number,
         "predictions": predictions,
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/keiba_ai_navi_scraper.py
+++ b/backend/batch/keiba_ai_navi_scraper.py
@@ -30,7 +30,6 @@ logger.setLevel(logging.INFO)
 # 定数
 BASE_URL = "https://horse-racing-ai-navi.com"
 SOURCE_NAME = "keiba-ai-navi"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0  # サーバー負荷軽減のための遅延
 
 # タイムゾーン
@@ -246,9 +245,6 @@ def save_predictions(
     scraped_at: datetime,
 ) -> None:
     """予想データをDynamoDBに保存."""
-    # TTL計算（7日後）
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -256,7 +252,6 @@ def save_predictions(
         "race_number": race_number,
         "predictions": convert_floats(predictions),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/kichiuma_scraper.py
+++ b/backend/batch/kichiuma_scraper.py
@@ -34,7 +34,6 @@ logger.setLevel(logging.INFO)
 # 定数
 SOURCE_NAME = "kichiuma-speed"
 BASE_URL = "https://kichiuma.net"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0
 
 # タイムゾーン
@@ -232,8 +231,6 @@ def save_indices(
     scraped_at: datetime,
 ) -> None:
     """スピード指数データをDynamoDBに保存."""
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -241,7 +238,6 @@ def save_indices(
         "race_number": race_number,
         "indices": convert_floats(indices),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/muryou_keiba_ai_scraper.py
+++ b/backend/batch/muryou_keiba_ai_scraper.py
@@ -24,7 +24,6 @@ logger.setLevel(logging.INFO)
 # 定数
 BASE_URL = "https://muryou-keiba-ai.jp"
 SOURCE_NAME = "muryou-keiba-ai"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0  # サーバー負荷軽減のための遅延
 MAX_ARCHIVE_PAGES = 5  # 月後半はレースが2ページ目以降に押し出されるため
 
@@ -238,9 +237,6 @@ def save_predictions(
     scraped_at: datetime,
 ) -> None:
     """予想データをDynamoDBに保存."""
-    # TTL計算（7日後）
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -248,7 +244,6 @@ def save_predictions(
         "race_number": race_number,
         "predictions": convert_floats(predictions),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/batch/umamax_scraper.py
+++ b/backend/batch/umamax_scraper.py
@@ -32,7 +32,6 @@ logger.setLevel(logging.INFO)
 # 定数
 BASE_URL = "https://umamax.com"
 SOURCE_NAME = "umamax"
-TTL_DAYS = 7
 REQUEST_DELAY_SECONDS = 1.0  # サーバー負荷軽減のための遅延
 
 # タイムゾーン
@@ -297,9 +296,6 @@ def save_predictions(
     scraped_at: datetime,
 ) -> None:
     """予想データをDynamoDBに保存."""
-    # TTL計算（7日後）
-    ttl = int((scraped_at + timedelta(days=TTL_DAYS)).timestamp())
-
     item = {
         "race_id": race_id,
         "source": SOURCE_NAME,
@@ -307,7 +303,6 @@ def save_predictions(
         "race_number": race_number,
         "predictions": convert_floats(predictions),
         "scraped_at": scraped_at.isoformat(),
-        "ttl": ttl,
     }
 
     table.put_item(Item=item)

--- a/backend/tests/batch/test_ai_shisu_scraper.py
+++ b/backend/tests/batch/test_ai_shisu_scraper.py
@@ -257,10 +257,7 @@ class TestSavePredictions:
         assert item["venue"] == "東京"
         assert item["race_number"] == 11
         assert item["predictions"] == predictions
-        assert "ttl" in item
-        # TTLは7日後
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
 
 class TestScrapeRaces:

--- a/backend/tests/batch/test_daily_speed_index_scraper.py
+++ b/backend/tests/batch/test_daily_speed_index_scraper.py
@@ -262,9 +262,7 @@ class TestSaveIndices:
         assert item["source"] == "daily-speed"
         assert item["venue"] == "東京"
         assert item["indices"] == indices
-        assert "ttl" in item
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
 
 class TestHandler:

--- a/backend/tests/batch/test_hrdb_race_scraper.py
+++ b/backend/tests/batch/test_hrdb_race_scraper.py
@@ -101,9 +101,7 @@ class TestConvertRaceRow:
         assert result["kaisai_kai"] == "01"
         assert result["kaisai_nichime"] == "08"
         assert result["scraped_at"] == scraped_at.isoformat()
-        # TTL: scraped_at + 14日
-        expected_ttl = int((scraped_at + timedelta(days=14)).timestamp())
-        assert result["ttl"] == expected_ttl
+        assert "ttl" not in result
 
     def test_ダートトラック(self):
         """TRACKCD先頭"2" → "ダート"."""
@@ -164,8 +162,7 @@ class TestConvertRunnerRow:
         assert result["odds"] == Decimal("3.4")
         assert result["popularity"] == 1
         assert result["scraped_at"] == scraped_at.isoformat()
-        expected_ttl = int((scraped_at + timedelta(days=14)).timestamp())
-        assert result["ttl"] == expected_ttl
+        assert "ttl" not in result
 
     def test_未確定の着順(self):
         """FIXPLC="00", RUNTM="0000" → None（フィルタ済み）."""

--- a/backend/tests/batch/test_jiro8_speed_index_scraper.py
+++ b/backend/tests/batch/test_jiro8_speed_index_scraper.py
@@ -195,9 +195,7 @@ class TestSaveIndices:
         assert item["venue"] == "東京"
         assert item["race_number"] == 11
         assert len(item["indices"]) == 1
-        assert "ttl" in item
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
     def test_scraped_atがISO形式で保存(self):
         """正常系: scraped_atがISO形式で保存される."""

--- a/backend/tests/batch/test_keiba_ai_athena_scraper.py
+++ b/backend/tests/batch/test_keiba_ai_athena_scraper.py
@@ -285,9 +285,7 @@ class TestSavePredictions:
         assert item["venue"] == "京都"
         assert item["race_number"] == 11
         assert item["predictions"] == predictions
-        assert "ttl" in item
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
     def test_scraped_atがISO形式で保存(self):
         """正常系: scraped_atがISO形式で保存される."""

--- a/backend/tests/batch/test_keiba_ai_navi_scraper.py
+++ b/backend/tests/batch/test_keiba_ai_navi_scraper.py
@@ -255,9 +255,7 @@ class TestSavePredictions:
         assert item["venue"] == "東京"
         assert item["race_number"] == 11
         assert len(item["predictions"]) == 1
-        assert "ttl" in item
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
     def test_scraped_atがISO形式で保存(self):
         """正常系: scraped_atがISO形式で保存される."""

--- a/backend/tests/batch/test_kichiuma_scraper.py
+++ b/backend/tests/batch/test_kichiuma_scraper.py
@@ -281,9 +281,7 @@ class TestSaveIndices:
         assert item["venue"] == "東京"
         assert item["race_number"] == 11
         assert item["indices"] == indices
-        assert "ttl" in item
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
 
 class TestHandler:

--- a/backend/tests/batch/test_muryou_keiba_ai_scraper.py
+++ b/backend/tests/batch/test_muryou_keiba_ai_scraper.py
@@ -476,10 +476,7 @@ class TestSavePredictions:
         assert item["predictions"] == [
             {"rank": 1, "score": Decimal("65.7"), "horse_number": 2, "horse_name": "馬A"},
         ]
-        assert "ttl" in item
-        # TTLは7日後
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
     def test_scraped_atがISO形式で保存(self):
         """正常系: scraped_atがISO形式で保存される."""

--- a/backend/tests/batch/test_umamax_scraper.py
+++ b/backend/tests/batch/test_umamax_scraper.py
@@ -278,9 +278,7 @@ class TestSavePredictions:
         assert item["source"] == "umamax"
         assert item["venue"] == "京都"
         assert item["race_number"] == 7
-        assert "ttl" in item
-        expected_ttl = int((scraped_at + timedelta(days=7)).timestamp())
-        assert item["ttl"] == expected_ttl
+        assert "ttl" not in item
 
     def test_floatがDecimalに変換されてDynamoDBに保存される(self):
         """正常系: predictionsのfloat値がDecimalに変換されてDynamoDBに保存される."""

--- a/cdk/stacks/api_stack.py
+++ b/cdk/stacks/api_stack.py
@@ -86,7 +86,6 @@ class BakenKaigiApiStack(Stack):
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,  # 開発環境用
-            time_to_live_attribute="ttl",
         )
 
         # スピード指数テーブル
@@ -104,7 +103,6 @@ class BakenKaigiApiStack(Stack):
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
-            time_to_live_attribute="ttl",
         )
 
         # Agent テーブル
@@ -348,7 +346,6 @@ class BakenKaigiApiStack(Stack):
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
-            time_to_live_attribute="ttl",
         )
 
         # Runners テーブル（HRDB出走馬データ）
@@ -366,7 +363,6 @@ class BakenKaigiApiStack(Stack):
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
-            time_to_live_attribute="ttl",
         )
         # horse_id での検索用 GSI
         runners_table.add_global_secondary_index(

--- a/cdk/tests/test_api_stack.py
+++ b/cdk/tests/test_api_stack.py
@@ -374,6 +374,21 @@ class TestApiStack:
                     {"AttributeName": "race_id", "KeyType": "HASH"},
                     {"AttributeName": "source", "KeyType": "RANGE"},
                 ],
+                "BillingMode": "PAY_PER_REQUEST",
+            },
+        )
+
+    def test_speed_indices_dynamodb_table(self, template):
+        """スピード指数データ用DynamoDBテーブルが存在すること."""
+        template.has_resource_properties(
+            "AWS::DynamoDB::Table",
+            {
+                "TableName": "baken-kaigi-speed-indices",
+                "KeySchema": [
+                    {"AttributeName": "race_id", "KeyType": "HASH"},
+                    {"AttributeName": "source", "KeyType": "RANGE"},
+                ],
+                "BillingMode": "PAY_PER_REQUEST",
             },
         )
 

--- a/cdk/tests/test_api_stack.py
+++ b/cdk/tests/test_api_stack.py
@@ -420,10 +420,6 @@ class TestApiStack:
                     {"AttributeName": "race_id", "KeyType": "RANGE"},
                 ],
                 "BillingMode": "PAY_PER_REQUEST",
-                "TimeToLiveSpecification": {
-                    "AttributeName": "ttl",
-                    "Enabled": True,
-                },
             },
         )
 
@@ -453,10 +449,6 @@ class TestApiStack:
                     {"AttributeName": "horse_number", "KeyType": "RANGE"},
                 ],
                 "BillingMode": "PAY_PER_REQUEST",
-                "TimeToLiveSpecification": {
-                    "AttributeName": "ttl",
-                    "Enabled": True,
-                },
             },
         )
 


### PR DESCRIPTION
## Summary
- 全9スクレーパーから `TTL_DAYS` 定数と DynamoDB アイテムの `ttl` フィールドを削除
- AI予想・スピード指数・HRDBレースデータが無期限に保持されるようになる
- モデル学習用の過去データ蓄積に必要な変更

## 対象ファイル
### スクレーパー（9ファイル）
- `ai_shisu_scraper.py` (TTL_DAYS=7 → 削除)
- `keiba_ai_athena_scraper.py` (TTL_DAYS=7 → 削除)
- `keiba_ai_navi_scraper.py` (TTL_DAYS=7 → 削除)
- `muryou_keiba_ai_scraper.py` (TTL_DAYS=7 → 削除)
- `umamax_scraper.py` (TTL_DAYS=7 → 削除)
- `jiro8_speed_index_scraper.py` (TTL_DAYS=7 → 削除)
- `kichiuma_scraper.py` (TTL_DAYS=7 → 削除)
- `daily_speed_index_scraper.py` (TTL_DAYS=7 → 削除)
- `hrdb_race_scraper.py` (TTL_DAYS=14 → 削除)

### テスト（9ファイル）
- TTL存在チェックを `assert "ttl" not in item` に変更

## Test plan
- [x] 全1887テストがパス（49件スキップ、失敗0件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)